### PR TITLE
feat: add init validation to Folios class

### DIFF
--- a/satcfdi/create/cancela/aceptacionrechazo.py
+++ b/satcfdi/create/cancela/aceptacionrechazo.py
@@ -1,5 +1,6 @@
 from collections.abc import Sequence
 from datetime import datetime
+from typing import Literal
 
 from ..w3.signature import signature_c14n_sha1
 from ...models import Signer
@@ -8,22 +9,23 @@ from ...xelement import XElement
 
 
 class Folios(ScalarMap):
-    def __init__(
-            self,
-            respuesta: str,
-            uuid: str = None,
-    ): 
+    def __init__(self, respuesta: Literal["Aceptacion", "Rechazo"], uuid: str = None):
         """
-        
-        :param respuesta: 
-        :param uuid: 
+
+        :param respuesta: "Rechazo" o "Aceptacion"
+        :param uuid: El UUID del documento que se desea aceptar o rechazar
         """
-        
-        super().__init__({
-            'Respuesta': respuesta,
-            'UUID': uuid,
-        })
-        
+        if respuesta not in ["Aceptacion", "Rechazo"]:
+            msg = f'respuesta must be "Aceptacion" or "Rechazo", found {respuesta} instead'
+            raise ValueError(msg)
+
+        super().__init__(
+            {
+                "Respuesta": respuesta,
+                "UUID": uuid,
+            }
+        )
+
 
 class SolicitudAceptacionRechazo(XElement):
     """
@@ -70,8 +72,3 @@ class SolicitudAceptacionRechazo(XElement):
             }
         )
         self['Signature'] = sig
-
-
-
-
-


### PR DESCRIPTION
# Description

Los folios de cancelación sólo aceptan como valor de respuesta "Aceptacion" o "Rechazo".
Teniendo en cuenta lo anterior, este PR añade una validación al crear una instancia de la clase Folios que levanta una excepción en caso de ingresar un valor diferente a los mencionados.
Además, también modifica el typehint del argumento y el docstring para reflejar mejor ese comportamiento.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] `test_swsapien_accept_reject` se ejecuta con éxito

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
