### PR TITLE
fix: rearange stamp table distribution on cfdi render

### DIFF
--- a/satcfdi/render/templates/TimbreFiscalDigital.html
+++ b/satcfdi/render/templates/TimbreFiscalDigital.html
@@ -1,8 +1,5 @@
 <table class="nb" style="margin-top: 4px">
 	<tr>
-		<td rowspan="4">
-			<img src="data:image/png;base64, {{ parent.verifica_url | qr_image }}" alt="QR Code" style="max-width: 120px;"/>
-		</td>
 		<td style="white-space: nowrap;"><b>Folio Fiscal:</b></td>
 		<td style="white-space: nowrap;">{{ c.UUID }}</td>
 		<td style="white-space: nowrap;"><b>Fecha de Certificación:</b></td>
@@ -20,7 +17,10 @@
 		{% endif %}
 	</tr>
 	<tr>
-		<td colspan="4">
+		<td>
+			<img src="data:image/png;base64, {{ parent.verifica_url | qr_image }}" alt="QR Code" style="max-width: 120px;"/>
+		</td>
+		<td colspan="3">
 			<div class="ciii">
 				<b>Sello del CFDI: </b> {{ c.SelloCFD | baa }}<br>
 				<b>Sello del SAT: </b> {{ c.SelloSAT | baa }}<br>


### PR DESCRIPTION
# Pull Request Template

## Description

Este PR reacomoda el posicionamiento de la tabla del Timbre Fiscal Digital en la representación impresa del CFDI, resolviendo el problema donde el texto sale de los márgenes establecidos.

Fixes #24 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Se han realizado pruebas manuales. Aquí el resultado:
![image](https://github.com/user-attachments/assets/d5d988b9-9cd9-4312-8ac5-547887b342dc)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings
