### PR TITLE
fix #29: fill TasaOCuotaP with zeros for comparison

### DIFF
--- a/satcfdi/create/compute.py
+++ b/satcfdi/create/compute.py
@@ -178,7 +178,7 @@ def make_pago_totales(pagos):
             impuestos[RETENCIONES_MAP[retencion["ImpuestoP"]]] += retencion["ImporteP"] * tipo_cambio
 
         for traslado in iterate((p["ImpuestosP"] or {}).get("TrasladosP")):
-            match (traslado["ImpuestoP"], traslado["TipoFactorP"], str(traslado["TasaOCuotaP"])):
+            match (traslado["ImpuestoP"], traslado["TipoFactorP"], str(traslado["TasaOCuotaP"]).ljust(8, '0')):
                 case ("002", "Tasa", "0.160000"):
                     impuestos['TotalTrasladosBaseIVA16'] += traslado["BaseP"] * tipo_cambio
                     impuestos['TotalTrasladosImpuestoIVA16'] += traslado["ImporteP"] * tipo_cambio


### PR DESCRIPTION
# Pull Request Template

## Description

Se añaden ceros al momento de comparar el nodo TasaOCuota para identificar los impuestos trasladados al generar un CEP

Fixes #29

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
