### PR TITLE
fix: adds None type to fields with None as default value

### DIFF
--- a/satcfdi/pacs/sat.py
+++ b/satcfdi/pacs/sat.py
@@ -574,16 +574,16 @@ class SAT(PAC):
 
     def recover_comprobante_request(
             self,
-            fecha_inicial: date = None,
-            fecha_final: date = None,
-            rfc_receptor: str | Sequence[str] = None,
-            rfc_emisor: str = None,
+            fecha_inicial: date | datetime | None = None,
+            fecha_final: date | datetime | None = None,
+            rfc_receptor: str | Sequence[str] | None = None,
+            rfc_emisor: str | None = None,
             tipo_solicitud: TipoDescargaMasivaTerceros | str = TipoDescargaMasivaTerceros.CFDI,
-            tipo_comprobante: TipoDeComprobante | str = None,
-            estado_comprobante: EstadoComprobante | str = None,
-            rfc_a_cuenta_terceros: str = None,
-            complemento: str = None,
-            uuid: str | UUID = None) -> dict:
+            tipo_comprobante: TipoDeComprobante | str | None = None,
+            estado_comprobante: EstadoComprobante | str | None = None,
+            rfc_a_cuenta_terceros: str | None = None,
+            complemento: str | None = None,
+            uuid: str | UUID | None = None) -> dict:
         """
         Esta operación permite solicitar la descarga de CFDIs o Metadata y como
         resultado devuelve un id de solicitud o estatus de la petición realizada.


### PR DESCRIPTION
# Pull Request Template

## Description

The typing for the `recover_comprobante_request` function is wrong. Multiple fields have `None` as default value, but the type doesn't include the `None` type. This PR fixes that.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Linter doesn't complain anymore about this issue

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
