### PR TITLE
fix: Evitar NoneType al no tener 'OtrosPagos' en Nómina

### DIFF
--- a/satcfdi/create/cfd/cfdi40.py
+++ b/satcfdi/create/cfd/cfdi40.py
@@ -666,15 +666,22 @@ class Comprobante(CFDI):
         else:
             receptor["UsoCFDI"] = "CN01"
 
+        valor_unitario = (
+            complemento_nomina.get('TotalPercepciones') or Decimal(0)
+        ) + (
+            complemento_nomina.get('TotalOtrosPagos') or Decimal(0)
+        )
+        
         concepto = Concepto(
             clave_prod_serv='84111505',
             cantidad=1,
             clave_unidad='ACT',
             descripcion='Pago de nómina',
-            valor_unitario=complemento_nomina.get('TotalPercepciones', 0) + complemento_nomina.get('TotalOtrosPagos', 0),
+            valor_unitario=valor_unitario,
             descuento=complemento_nomina.get('TotalDeducciones'),
             objeto_imp="03"
         )
+        
         return cls(
             emisor=emisor,
             lugar_expedicion=lugar_expedicion,


### PR DESCRIPTION

## Description

Usando el template de readthedocs para la generación de nómina, me percaté que la función falla al intentar realizar una suma de un Decimal con un NoneType, se realizó una corrección para asegurarse de que el valor obtenido, ya sea de "TotalPercepciones" o "TotalOtrosPagos", sea un '0' decimal en caso de que no exista alguno de los dos valores (pero si la key).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Se realizó la ejecución del la función usando la plantilla, y otra ejecución agregando otros pagos para verificar que la funcionalidad original funciona.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
