### PR TITLE
fix: Cancelar cfdi con el uuid en lowercase no funciona para SWSapien

### DIFF
--- a/satcfdi/pacs/swsapien.py
+++ b/satcfdi/pacs/swsapien.py
@@ -144,7 +144,7 @@ class SWSapien(PAC):
         )
 
     def cancel(self, cfdi: CFDI, reason: CancelReason, substitution_id: str = None, signer: Signer = None) -> CancelationAcknowledgment:
-        document_id = cfdi["Complemento"]["TimbreFiscalDigital"]["UUID"]
+        document_id = cfdi["Complemento"]["TimbreFiscalDigital"]["UUID"].upper()
         rfc = cfdi["Emisor"]["Rfc"]
         path = f"cfdi33/cancel/{rfc}/{document_id}/{reason.value}"
         if substitution_id:


### PR DESCRIPTION
## Description

Este pull request es solo cambio menor a la forma en que se manejan los UUID en el método `cancel` de `swsapien.py`. Ahora el UUID del cfdi proporcionado siempre se convierte a uppercase antes de usarse, lo que  evitar un `KeyNotFound`al generar el `CancelationAcknowledgment` si el UUID no viene en uppercase de antemano.

Fixes 

- Siempre conviertir el UUID en cfdi["Complemento"]["TimbreFiscalDigital"]["UUID"] a mayúsculas en el método cancel.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Fue probado generando cancelaciones con UUID en mayúsculas y minusculas en el ambiente de pruebas de SWSapien.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
