### PR TITLE
feat(diot): soporte para nueva plataforma DIOT 2025 (pstcdi.clouda.sat.gob.mx)

### DIFF
--- a/satcfdi/catalogs/__init__.py
+++ b/satcfdi/catalogs/__init__.py
@@ -8,18 +8,21 @@ current_dir = os.path.dirname(__file__)
 
 db_file = os.path.join(current_dir, "catalogs.db")
 conn = sqlite3.connect(db_file, check_same_thread=False)
-c = conn.cursor()
 
 
 def select(catalog_name, key):
-    c.execute(f"SELECT value FROM {catalog_name} WHERE key = ?", (pickle.dumps(key),))
-    if ds := c.fetchone():
-        return pickle.loads(ds[0])
+    with conn: 
+        c = conn.cursor()
+        c.execute(f"SELECT value FROM {catalog_name} WHERE key = ?", (pickle.dumps(key),))
+        if ds := c.fetchone():
+            return pickle.loads(ds[0])
 
 
 def select_all(catalog_name):
-    c.execute(f"SELECT key, value FROM {catalog_name}")
-    return {pickle.loads(k): pickle.loads(v) for k, v in c.fetchall()}
+    with conn: 
+        c = conn.cursor()
+        c.execute(f"SELECT key, value FROM {catalog_name}")
+        return {pickle.loads(k): pickle.loads(v) for k, v in c.fetchall()}
 
 
 def catalog_code(catalog_name, key, index=None):
@@ -60,8 +63,10 @@ def split_at_upper(word: str):
 
 
 def trans(k):
-    c.execute(f"SELECT value FROM Translations WHERE key = ?", (k,))
-    if res := c.fetchone():
-        return res[0]
+    with conn: 
+        c = conn.cursor()
+        c.execute(f"SELECT value FROM Translations WHERE key = ?", (k,))
+        if res := c.fetchone():
+            return res[0]
 
-    return split_at_upper(k)
+        return split_at_upper(k)

--- a/satcfdi/diot/__init__.py
+++ b/satcfdi/diot/__init__.py
@@ -211,6 +211,7 @@ class ProveedorTercero:
             w(302261, 1, 1, self.devoluciones)
 
     def to_list(self):
+        """Formato legacy (25 campos, windows-1252). Usado por DIOT.export(version=1)."""
         return [
             self.tipo_tercero,
             self.tipo_operacion,
@@ -236,6 +237,45 @@ class ProveedorTercero:
             self.iva_exento,
             self.retenido,
             self.devoluciones
+        ]
+
+    def to_list_v2(self):
+        """
+        Formato nuevo plataforma DIOT (pstcdi.clouda.sat.gob.mx), vigente desde febrero 2025.
+        Genera una lista de 24 campos separados por '|', codificado en UTF-8.
+
+        Referencia: Instructivo para el armado del archivo de carga masiva - SAT 2025.
+        Los campos sin equivalente en el modelo actual se dejan vacíos para
+        compatibilidad con el layout oficial.
+        """
+        rfc_str = str(self.rfc) if self.rfc else ""
+        pais_str = str(self.pais) if self.pais else ""
+
+        return [
+            int(self.tipo_tercero),           # 1.  Tipo Tercero
+            int(self.tipo_operacion),          # 2.  Tipo Operación
+            rfc_str,                           # 3.  RFC del proveedor nacional
+            self.id_fiscal or "",             # 4.  Número de ID Fiscal (extranjero)
+            self.nombre_extranjero or "",     # 5.  Nombre del extranjero
+            pais_str,                          # 6.  País de residencia
+            self.nacionalidad or "",          # 7.  Nacionalidad
+            self.iva16 or "",                 # 8.  Actos/actividades IVA 16%
+            "",                                # 9.  IVA 16% pagado (desglose nuevo)
+            self.iva16_na or "",              # 10. IVA 16% no acreditable
+            "",                                # 11. IVA 16% NA (bienes tangibles)
+            "",                                # 12. IVA 16% NA (servicios/intangibles)
+            self.iva_rfn or "",               # 13. Actos región fronteriza norte (8%)
+            "",                                # 14. IVA RFN calculado
+            self.iva_rfn_na or "",            # 15. IVA RFN no acreditable
+            self.iva_import16 or "",          # 16. Actos importación IVA 16%
+            self.iva_import16_na or "",       # 17. IVA importación no acreditable
+            "",                                # 18. IVA importación NA (tangibles)
+            "",                                # 19. IVA importación NA (intangibles)
+            self.iva_import_exento or "",     # 20. Importación exenta
+            self.iva0 or "",                  # 21. Actos tasa 0%
+            self.iva_exento or "",            # 22. Actos exentos nacionales
+            self.retenido or "",              # 23. IVA retenido por el contribuyente
+            self.devoluciones or "",          # 24. Devoluciones/descuentos/bonificaciones
         ]
 
 
@@ -426,10 +466,36 @@ class DIOT:
 
         return f"{rfc}{v_dem}{n_formulario}{ver_clte}{ver_form}{period}{mes_inicial}{period}{mes_final}{anio}{mes}{dia}{hora}{suffix}"
 
-    def export(self, target):
-        for p in self.proveedores:
-            target.write("|".join(str(v or "") for v in p.to_list()).encode('windows-1252'))
-            target.write(b"|\r\n")
+    def export(self, target, version: int = 2):
+        """
+        Exporta el archivo TXT para carga batch en la plataforma DIOT del SAT.
+
+        :param target: Objeto tipo file abierto en modo binario ('wb').
+        :param version: Versión del formato de exportación.
+            - 1: Formato legacy (24 campos, encoding windows-1252).
+              Compatible con la plataforma anterior (pre-febrero 2025).
+            - 2: Nuevo formato (24 campos, encoding UTF-8).
+              Requerido por la nueva plataforma pstcdi.clouda.sat.gob.mx
+              vigente desde febrero 2025. (Default)
+
+        Ejemplo de uso (nueva plataforma)::
+
+            with open('diot_batch.txt', 'wb') as f:
+                diot.export(f)  # version=2 por defecto
+
+        Ejemplo de uso (plataforma legacy)::
+
+            with open('diot_batch.txt', 'wb') as f:
+                diot.export(f, version=1)
+        """
+        if version == 2:
+            for p in self.proveedores:
+                line = "|".join(str(v) for v in p.to_list_v2())
+                target.write((line + "|\r\n").encode('utf-8'))
+        else:
+            for p in self.proveedores:
+                target.write("|".join(str(v or "") for v in p.to_list()).encode('windows-1252'))
+                target.write(b"|\r\n")
 
     def plain_bytes(self) -> bytes:
         with BytesIO() as b:


### PR DESCRIPTION
## Descripción

Resuelve el issue #66 — agrega soporte para generar el archivo TXT de carga batch compatible con la **nueva plataforma DIOT del SAT** (`pstcdi.clouda.sat.gob.mx`), vigente desde febrero 2025 y obligatoria desde agosto 2025.

## Cambios

### `ProveedorTercero.to_list_v2()`
Nuevo método que genera la lista de 24 campos según el layout actualizado del SAT:
- Encoding **UTF-8** (la plataforma anterior requería `windows-1252`)
- Campos con nuevos desgloses requeridos por el instructivo oficial SAT 2025
- Campos sin equivalente en el modelo actual se dejan vacíos para compatibilidad con el layout oficial

### `DIOT.export(target, version=2)`
Se agrega el parámetro `version`:
- `version=2` *(default)*: nuevo formato UTF-8 para `pstcdi.clouda.sat.gob.mx`
- `version=1`: formato legacy `windows-1252` para compatibilidad hacia atrás con la plataforma DEMC anterior

## Uso

```python
# Nueva plataforma (default desde esta versión)
with open('diot_batch.txt', 'wb') as f:
    diot.export(f)  # version=2

# Plataforma legacy (compatibilidad hacia atrás)
with open('diot_batch.txt', 'wb') as f:
    diot.export(f, version=1)
```

## Referencias
- [Issue #66](https://github.com/SAT-CFDI/python-satcfdi/issues/66)
- [Instructivo para el armado del archivo de carga masiva — SAT](https://wwwmat.sat.gob.mx/cs/Satellite?blobcol=urldata&blobkey=id&blobtable=MungoBlobs&blobwhere=1461174783775&ssbinary=true)
- Nueva plataforma DIOT: https://pstcdi.clouda.sat.gob.mx