### PR TITLE
feat(transform): agrega soporte para el complemento HidroYPetro

### DIFF
--- a/satcfdi/transform/objectify.py
+++ b/satcfdi/transform/objectify.py
@@ -14896,6 +14896,10 @@ def s_estado_de_cuenta_combustible2(cls, node):
     if node.attrib.get('tipoOperacion') == 'Tarjeta':
         return estado_de_cuenta_combustible2(cls, node)
     raise NamespaceMismatchError(node)
+def s_hidro_y_petro0(cls, node):
+    if node.attrib.get('Version') == '1.0':
+        return default_objectify(cls, node)
+    raise NamespaceMismatchError(node)
 def s_inst_educativas0(cls, node):
     if node.attrib.get('version') == '1.0':
         return inst_educativas0(cls, node)
@@ -15090,6 +15094,7 @@ cfdi_objectify = {
     '{http://www.sat.gob.mx/donat}Donatarias': s_donatarias0,
     '{http://www.sat.gob.mx/ecb}EstadoDeCuentaBancario': s_estado_de_cuenta_bancario0,
     '{http://www.sat.gob.mx/ecc}EstadoDeCuentaCombustible': s_estado_de_cuenta_combustible2,
+    '{http://www.sat.gob.mx/hidrocarburospetroliferos}HidroYPetro': s_hidro_y_petro0,
     '{http://www.sat.gob.mx/iedu}instEducativas': s_inst_educativas0,
     '{http://www.sat.gob.mx/implocal}ImpuestosLocales': s_impuestos_locales0,
     '{http://www.sat.gob.mx/ine}INE': s_ine0,

--- a/satcfdi/transform/schemas.py
+++ b/satcfdi/transform/schemas.py
@@ -4036,6 +4036,10 @@ def estado_de_cuenta_combustible2(col, data):
     col.add_map('ecc', 'http://www.sat.gob.mx/ecc')
     col.add_schema('http://www.sat.gob.mx/ecc http://www.sat.gob.mx/sitio_internet/cfd/ecc/ecc.xsd')
     col.add_base('www.sat.gob.mx/sitio_internet/cfd/ecc/ecc.xsd')
+def hidro_y_petro0(col, data):
+    col.add_map('hidroypetro', 'http://www.sat.gob.mx/hidrocarburospetroliferos')
+    col.add_schema('http://www.sat.gob.mx/hidrocarburospetroliferos http://www.sat.gob.mx/sitio_internet/cfd/hidrocarburospetroliferos/hidrocarburospetroliferos.xsd')
+    col.add_base('www.sat.gob.mx/sitio_internet/cfd/hidrocarburospetroliferos/hidrocarburospetroliferos.xsd')
 def inst_educativas0(col, data):
     col.add_map('iedu', 'http://www.sat.gob.mx/iedu')
     col.add_schema('http://www.sat.gob.mx/iedu http://www.sat.gob.mx/sitio_internet/cfd/iedu/iedu.xsd')
@@ -4328,6 +4332,9 @@ def s_estado_de_cuenta_bancario0(col, data):
 def s_estado_de_cuenta_combustible2(col, data):
     if data.get('TipoOperacion') == 'Tarjeta':
         estado_de_cuenta_combustible2(col, data)
+def s_hidro_y_petro0(col, data):
+    if data.get('Version') == '1.0':
+        hidro_y_petro0(col, data)
 def s_inst_educativas0(col, data):
     if data.get('Version') == '1.0':
         inst_educativas0(col, data)
@@ -4507,6 +4514,7 @@ cfdi_schemas = {
     '{http://www.sat.gob.mx/donat}Donatarias': s_donatarias0,
     '{http://www.sat.gob.mx/ecb}EstadoDeCuentaBancario': s_estado_de_cuenta_bancario0,
     '{http://www.sat.gob.mx/ecc}EstadoDeCuentaCombustible': s_estado_de_cuenta_combustible2,
+    '{http://www.sat.gob.mx/hidrocarburospetroliferos}HidroYPetro': s_hidro_y_petro0,
     '{http://www.sat.gob.mx/iedu}instEducativas': s_inst_educativas0,
     '{http://www.sat.gob.mx/implocal}ImpuestosLocales': s_impuestos_locales0,
     '{http://www.sat.gob.mx/ine}INE': s_ine0,

--- a/satcfdi/transform/schemas/www.sat.gob.mx/sitio_internet/cfd/hidrocarburospetroliferos/hidrocarburospetroliferos.xsd
+++ b/satcfdi/transform/schemas/www.sat.gob.mx/sitio_internet/cfd/hidrocarburospetroliferos/hidrocarburospetroliferos.xsd
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:hidrocarburospetroliferos="http://www.sat.gob.mx/hidrocarburospetroliferos" xmlns:catHidroYPetro="http://www.sat.gob.mx/sitio_internet/cfd/catalogos/HidrocarburosPetro" targetNamespace="http://www.sat.gob.mx/hidrocarburospetroliferos" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:import namespace="http://www.sat.gob.mx/sitio_internet/cfd/catalogos/HidrocarburosPetro" schemaLocation="http://www.sat.gob.mx/sitio_internet/cfd/catalogos/HidrocarburosPetro/catHidroYPetro.xsd"/>
+	<xs:element name="HidroYPetro">
+		<xs:annotation>
+			<xs:documentation>Complemento concepto para incorporar al Comprobante Fiscal Digital por Internet (CFDI) la información sobre los permisos otorgados por la autoridad competente referentes a operaciones de hidrocarburos y petrolíferos.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:attribute name="Version" use="required" fixed="1.0">
+				<xs:annotation>
+					<xs:documentation>Atributo requerido con valor prefijado a 1.0 que indica la versión del complemento concepto para la facturación de Hidrocarburos y Petrolíferos.</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="TipoPermiso" type="catHidroYPetro:c_TipoPermiso" use="required">
+				<xs:annotation>
+					<xs:documentation>Atributo requerido para registrar el tipo de permiso cuando éste haya sido otorgado por la autoridad competente.</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="NumeroPermiso" use="required">
+				<xs:annotation>
+					<xs:documentation>Atributo requerido para registrar el número de permiso otorgado por la autoridad competente, de acuerdo con la nomenclatura de la columna “Nomenclatura del número de permiso” del catálogo c_TipoPermiso.</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:minLength value="15"/>
+						<xs:maxLength value="35"/>
+						<xs:whiteSpace value="collapse"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="ClaveHYP" type="catHidroYPetro:c_ClaveHYP" use="required">
+				<xs:annotation>
+					<xs:documentation>Atributo requerido para registrar la clave correspondiente a  hidrocarburos y petrolíferos.</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="SubProductoHYP" type="catHidroYPetro:c_SubProductoHYP" use="required">
+				<xs:annotation>
+					<xs:documentation>Atributo requerido para registrar el subtipo del hidrocarburo y petrolífero.</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/satcfdi/transform/xmlify.py
+++ b/satcfdi/transform/xmlify.py
@@ -14543,6 +14543,18 @@ def traslado8(name, data):
     self.attrib['tasa'] = fmt_decimal(data['Tasa'])
     self.attrib['importe'] = fmt_decimal(data['Importe'])
     return self
+def hidro_y_petro0(name, data):
+    col = SchemaCollector()
+    cfdi_schemas[data.tag](col, data)
+    self = Element('{%s}%s' % ('http://www.sat.gob.mx/hidrocarburospetroliferos', name), nsmap=col.nsmap)
+    self.attrib['Version'] = data['Version']
+    self.attrib['TipoPermiso'] = data['TipoPermiso']
+    self.attrib['NumeroPermiso'] = data['NumeroPermiso']
+    if (a := data.get('ClaveHYP')) is not None:
+        self.attrib['ClaveHYP'] = a
+    if (a := data.get('SubProductoHYP')) is not None:
+        self.attrib['SubProductoHYP'] = a
+    return self
 def inst_educativas0(name, data):
     col = SchemaCollector()
     cfdi_schemas[data.tag](col, data)
@@ -15718,6 +15730,10 @@ def s_estado_de_cuenta_combustible2(data):
     if data.get('TipoOperacion') == 'Tarjeta':
         return estado_de_cuenta_combustible2('EstadoDeCuentaCombustible', data)
     raise NamespaceMismatchError(data)
+def s_hidro_y_petro0(data):
+    if data.get('Version') == '1.0':
+        return hidro_y_petro0('HidroYPetro', data)
+    raise NamespaceMismatchError(data)
 def s_inst_educativas0(data):
     if data.get('Version') == '1.0':
         return inst_educativas0('instEducativas', data)
@@ -15912,6 +15928,7 @@ cfdi_xmlify = {
     '{http://www.sat.gob.mx/donat}Donatarias': s_donatarias0,
     '{http://www.sat.gob.mx/ecb}EstadoDeCuentaBancario': s_estado_de_cuenta_bancario0,
     '{http://www.sat.gob.mx/ecc}EstadoDeCuentaCombustible': s_estado_de_cuenta_combustible2,
+    '{http://www.sat.gob.mx/hidrocarburospetroliferos}HidroYPetro': s_hidro_y_petro0,
     '{http://www.sat.gob.mx/iedu}instEducativas': s_inst_educativas0,
     '{http://www.sat.gob.mx/implocal}ImpuestosLocales': s_impuestos_locales0,
     '{http://www.sat.gob.mx/ine}INE': s_ine0,


### PR DESCRIPTION
## Description
Al intentar crear una cadena original da el error siguiente 
 KeyError('{http://www.sat.gob.mx/hidrocarburospetroliferos}HidroYPetro')
este es el codigo para reproducirlo
from satcfdi.cfdi import CFDI

xml_content = """<?xml version="1.0" encoding="utf-8"?>
<cfdi:Comprobante xmlns:cfdi="http://www.sat.gob.mx/cfd/4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="4.0" Sello="MOCK" NoCertificado="00001000000504465930" Certificado="MOCK" SubTotal="1000.00" Moneda="MXN" Total="1160.00" TipoDeComprobante="I" Exportacion="01" MetodoPago="PUE" LugarExpedicion="64000" Fecha="2026-05-13T10:00:00">
  <cfdi:Emisor Rfc="EKU9003173C9" Nombre="ESCUELA S.A." RegimenFiscal="601" />
  <cfdi:Receptor Rfc="URE180429BY4" Nombre="UNIVERSIDAD" DomicilioFiscalReceptor="06500" RegimenFiscalReceptor="601" UsoCFDI="G03" />
  <cfdi:Conceptos>
    <cfdi:Concepto ClaveProdServ="15101514" Cantidad="50.00" ClaveUnidad="LTR" Unidad="Litros" Descripcion="GASOLINA" ValorUnitario="20.00" Importe="1000.00" ObjetoImp="02">
      <cfdi:ComplementoConcepto>
        <hidroypetro:HidroYPetro xmlns:hidroypetro="http://www.sat.gob.mx/hidrocarburospetroliferos" Version="1.0" TipoPermiso="PER01" NumeroPermiso="PL/12345/EXP/ES/2015" ClaveHYP="H10" SubProductoHYP="S20" />
      </cfdi:ComplementoConcepto>
    </cfdi:Concepto>
  </cfdi:Conceptos>
</cfdi:Comprobante>
"""

try:
    # En una instalación limpia (sin modificar), esto arrojará KeyError
    cfdi = CFDI.from_string(xml_content.encode('utf-8'))
    xml_str = cfdi.to_xml()
    print("Éxito: XML generado correctamente.")
except KeyError as e:
    print(f"Error reproducido: {repr(e)}")

Se soluciono con los cambios que hice ademas de añadir el xsd a la ruta "satcfdi/transform/schemas/www.sat.gob.mx/sitio_internet/cfd/hidrocarburospetroliferos" tuve que crear la carpeta ya que no se encontraba 
Es la primera vez que hago esto no se si es correcto saludos