### PR TITLE
Add Facturama Carta Porte, Web API, and more complements

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -69,7 +69,7 @@ ____________________
 
   * Comercio Digital
   * Diverza
-  * Facturama (Multiemisor)
+  * Facturama (Multiemisor y API Web)
   * Finkok
   * Prodigia
   * SW Sapien

--- a/satcfdi/pacs/facturama.py
+++ b/satcfdi/pacs/facturama.py
@@ -1,16 +1,24 @@
 """
-Facturama Multiemisor PAC adapter.
+Facturama PAC adapters (Multiemisor and API Web).
 
-Facturama seals and stamps from a JSON payload (CSD must already be uploaded).
-Pre-signed XML stamp is not supported by their public Multiemisor API.
+Facturama seals and stamps from a JSON payload. Pre-signed XML stamp is not
+supported by their public Multiemisor/Web JSON APIs.
 
 Supported TipoDeComprobante: I, E, T, P (Pagos 2.0), N (Nómina 1.2).
+
+Item CFDIs may include:
+- Carta Porte 3.1 (NameId ``36``) — Multiemisor and Web
+- Donativos (NameId ``9``) — Multiemisor and Web
+- Leyendas fiscales (TaxLegends)
+- Impuestos locales (via item Taxes with ``IsFederalTax: false``)
+- Comercio exterior 2.0 (NameId ``26``) — **API Web only** (:class:`FacturamaWeb`)
 
 Docs: https://apisandbox.facturama.mx/guias
 """
 from __future__ import annotations
 
 import base64
+from collections.abc import Mapping
 from datetime import date, datetime
 from decimal import Decimal
 from enum import Enum
@@ -30,7 +38,7 @@ from . import (
 from .. import __version__
 from ..cfdi import CFDI
 from ..exceptions import DocumentNotFoundError, ResponseError
-from ..models import Signer
+from ..models import Code, Signer
 from ..utils import iterate
 
 _TAX_NAME = {
@@ -41,12 +49,38 @@ _TAX_NAME = {
 
 _ITEM_TIPOS = {"I", "E", "T"}
 _SUPPORTED_TIPOS = _ITEM_TIPOS | {"P", "N"}
+_ITEM_COMPLEMENT_KEYS = {
+    "TimbreFiscalDigital",
+    "Pagos",
+    "Nomina",
+    "Pago",
+    "CartaPorte",
+    "Donatarias",
+    "LeyendasFiscales",
+    "ImpuestosLocales",
+    "ComercioExterior",
+}
+_CARTA_PORTE_NAME_ID = "36"
+_DONATION_NAME_ID = "9"
+_FOREIGN_TRADE_NAME_ID = "26"
 
 
 def _enum_value(val):
     if isinstance(val, Enum):
         return val.value
     return val
+
+
+def _code_str(val) -> str | None:
+    if val is None:
+        return None
+    if isinstance(val, Code):
+        return str(val.code)
+    if hasattr(val, "code") and not isinstance(val, type):
+        code = getattr(val, "code", None)
+        if code is not None and not callable(code):
+            return str(code)
+    return str(_enum_value(val))
 
 
 def _num(val) -> float | None:
@@ -89,6 +123,11 @@ def _as_bool(val) -> bool | None:
     return bool(val)
 
 
+def _set_opt(target: dict, key: str, value) -> None:
+    if value is not None and value != "":
+        target[key] = value
+
+
 def _tax_entry(
     tax: dict,
     *,
@@ -108,6 +147,7 @@ def _tax_entry(
     entry = {
         "Name": name,
         "IsRetention": is_retention,
+        "IsFederalTax": True,
         "Base": _num(tax.get(base_key)),
         "Total": _num(tax.get(importe_key)) or 0.0,
     }
@@ -147,7 +187,806 @@ def _complement_node(cfdi: CFDI, name: str):
         or "TipoNomina" in complemento
     ):
         return complemento
+    if name == "CartaPorte" and (
+        "CartaPorte" in tag
+        or (
+            "TranspInternac" in complemento
+            and ("Ubicaciones" in complemento or "Mercancias" in complemento)
+        )
+    ):
+        return complemento
+    if name == "Donatarias" and (
+        "donat" in tag.lower()
+        or "NoAutorizacion" in complemento
+    ):
+        return complemento
+    if name == "LeyendasFiscales" and (
+        "leyendasFiscales" in tag
+        or (
+            "Leyenda" in complemento
+            and "NoAutorizacion" not in complemento
+            and not isinstance(complemento.get("Leyenda"), str)
+        )
+    ):
+        return complemento
+    if name == "ImpuestosLocales" and (
+        "implocal" in tag.lower()
+        or "TotaldeTraslados" in complemento
+        or "TotaldeRetenciones" in complemento
+    ):
+        return complemento
+    if name == "ComercioExterior" and (
+        "ComercioExterior" in tag
+        or "ClaveDePedimento" in complemento
+        or "TotalUSD" in complemento
+    ):
+        return complemento
     return None
+
+
+def _is_carta_porte_body(complemento) -> bool:
+    if not complemento or not isinstance(complemento, Mapping):
+        return False
+    tag = getattr(complemento, "tag", "") or ""
+    if "CartaPorte" in tag:
+        return True
+    return "TranspInternac" in complemento and (
+        "Ubicaciones" in complemento or "Mercancias" in complemento
+    )
+
+
+def _is_known_item_complement_body(complemento) -> bool:
+    if not complemento or not isinstance(complemento, Mapping):
+        return False
+    return (
+        _is_carta_porte_body(complemento)
+        or "NoAutorizacion" in complemento
+        or ("Leyenda" in complemento and "Version" in complemento)
+        or "TotaldeTraslados" in complemento
+        or "TotaldeRetenciones" in complemento
+        or "ClaveDePedimento" in complemento
+    )
+
+
+def _map_domicilio(domicilio) -> dict | None:
+    if not domicilio:
+        return None
+    mapped: dict[str, Any] = {}
+    _set_opt(mapped, "Calle", domicilio.get("Calle") and str(domicilio["Calle"]))
+    _set_opt(
+        mapped,
+        "NumeroExterior",
+        domicilio.get("NumeroExterior") and str(domicilio["NumeroExterior"]),
+    )
+    _set_opt(
+        mapped,
+        "NumeroInterior",
+        domicilio.get("NumeroInterior") and str(domicilio["NumeroInterior"]),
+    )
+    _set_opt(mapped, "Colonia", _code_str(domicilio.get("Colonia")))
+    _set_opt(mapped, "Localidad", _code_str(domicilio.get("Localidad")))
+    _set_opt(
+        mapped,
+        "Referencia",
+        domicilio.get("Referencia") and str(domicilio["Referencia"]),
+    )
+    _set_opt(mapped, "Municipio", _code_str(domicilio.get("Municipio")))
+    _set_opt(mapped, "Estado", _code_str(domicilio.get("Estado")))
+    _set_opt(mapped, "Pais", _code_str(domicilio.get("Pais")))
+    _set_opt(
+        mapped,
+        "CodigoPostal",
+        domicilio.get("CodigoPostal") and str(domicilio["CodigoPostal"]),
+    )
+    return mapped or None
+
+
+def _map_regimenes_aduaneros(regimenes) -> list[dict]:
+    result = []
+    for regimen in iterate(regimenes):
+        if isinstance(regimen, Mapping) and "RegimenAduanero" in regimen:
+            code = _code_str(regimen["RegimenAduanero"])
+        else:
+            code = _code_str(regimen)
+        if code:
+            result.append({"RegimenAduanero": code})
+    return result
+
+
+def _map_partes_transporte(partes) -> list[dict]:
+    result = []
+    for parte in iterate(partes):
+        if isinstance(parte, Mapping) and "ParteTransporte" in parte:
+            code = _code_str(parte["ParteTransporte"])
+        else:
+            code = _code_str(parte)
+        if code:
+            result.append({"ParteTransporte": code})
+    return result
+
+
+def _map_ubicacion(ubicacion) -> dict:
+    mapped: dict[str, Any] = {
+        "TipoUbicacion": str(ubicacion["TipoUbicacion"]),
+        "RFCRemitenteDestinatario": str(ubicacion["RFCRemitenteDestinatario"]),
+        "FechaHoraSalidaLlegada": _format_date(ubicacion["FechaHoraSalidaLlegada"]),
+    }
+    _set_opt(mapped, "IDUbicacion", ubicacion.get("IDUbicacion") and str(ubicacion["IDUbicacion"]))
+    _set_opt(
+        mapped,
+        "NombreRemitenteDestinatario",
+        ubicacion.get("NombreRemitenteDestinatario")
+        and str(ubicacion["NombreRemitenteDestinatario"]),
+    )
+    _set_opt(mapped, "NumRegIdTrib", ubicacion.get("NumRegIdTrib") and str(ubicacion["NumRegIdTrib"]))
+    _set_opt(mapped, "ResidenciaFiscal", _code_str(ubicacion.get("ResidenciaFiscal")))
+    _set_opt(mapped, "NumEstacion", _code_str(ubicacion.get("NumEstacion")))
+    _set_opt(
+        mapped,
+        "NombreEstacion",
+        ubicacion.get("NombreEstacion") and str(ubicacion["NombreEstacion"]),
+    )
+    _set_opt(mapped, "NavegacionTrafico", _code_str(ubicacion.get("NavegacionTrafico")))
+    _set_opt(mapped, "TipoEstacion", _code_str(ubicacion.get("TipoEstacion")))
+    if ubicacion.get("DistanciaRecorrida") is not None:
+        mapped["DistanciaRecorrida"] = _num(ubicacion["DistanciaRecorrida"])
+    if domicilio := _map_domicilio(ubicacion.get("Domicilio")):
+        mapped["Domicilio"] = domicilio
+    return mapped
+
+
+def _map_cantidad_transporta(items) -> list[dict]:
+    result = []
+    for item in iterate(items):
+        entry: dict[str, Any] = {
+            "Cantidad": _num(item["Cantidad"]),
+            "IDOrigen": str(item["IDOrigen"]),
+            "IDDestino": str(item["IDDestino"]),
+        }
+        _set_opt(entry, "CvesTransporte", _code_str(item.get("CvesTransporte")))
+        result.append(entry)
+    return result
+
+
+def _map_documentacion_aduanera(items) -> list[dict]:
+    result = []
+    for item in iterate(items):
+        entry: dict[str, Any] = {
+            "TipoDocumento": _code_str(item["TipoDocumento"]),
+        }
+        _set_opt(entry, "NumPedimento", item.get("NumPedimento") and str(item["NumPedimento"]))
+        _set_opt(
+            entry,
+            "IdentDocAduanero",
+            item.get("IdentDocAduanero") and str(item["IdentDocAduanero"]),
+        )
+        _set_opt(entry, "RFCImpo", item.get("RFCImpo") and str(item["RFCImpo"]))
+        result.append(entry)
+    return result
+
+
+def _map_guias_identificacion(items) -> list[dict]:
+    result = []
+    for item in iterate(items):
+        result.append(
+            {
+                "NumeroGuiaIdentificacion": str(item["NumeroGuiaIdentificacion"]),
+                "DescripGuiaIdentificacion": str(item["DescripGuiaIdentificacion"]),
+                "PesoGuiaIdentificacion": _num(item["PesoGuiaIdentificacion"]),
+            }
+        )
+    return result
+
+
+def _map_detalle_mercancia(detalle) -> dict | None:
+    if not detalle:
+        return None
+    mapped: dict[str, Any] = {
+        "UnidadPesoMerc": _code_str(detalle["UnidadPesoMerc"]),
+        "PesoBruto": _num(detalle["PesoBruto"]),
+        "PesoNeto": _num(detalle["PesoNeto"]),
+        "PesoTara": _num(detalle["PesoTara"]),
+    }
+    if detalle.get("NumPiezas") is not None:
+        mapped["NumPiezas"] = int(detalle["NumPiezas"])
+    return mapped
+
+
+def _map_mercancia(mercancia) -> dict:
+    mapped: dict[str, Any] = {
+        "BienesTransp": _code_str(mercancia["BienesTransp"]),
+        "Descripcion": str(mercancia["Descripcion"]),
+        "Cantidad": _num(mercancia["Cantidad"]),
+        "ClaveUnidad": _code_str(mercancia["ClaveUnidad"]),
+        "PesoEnKg": _num(mercancia["PesoEnKg"]),
+    }
+    optional_str = (
+        ("ClaveSTCC", "ClaveSTCC"),
+        ("Unidad", "Unidad"),
+        ("Dimensiones", "Dimensiones"),
+        ("DescripEmbalaje", "DescripEmbalaje"),
+        ("NombreIngredienteActivo", "NombreIngredienteActivo"),
+        ("NomQuimico", "NomQuimico"),
+        ("DenominacionGenericaProd", "DenominacionGenericaProd"),
+        ("DenominacionDistintivaProd", "DenominacionDistintivaProd"),
+        ("Fabricante", "Fabricante"),
+        ("LoteMedicamento", "LoteMedicamento"),
+        ("RegistroSanitarioFolioAutorizacion", "RegistroSanitarioFolioAutorizacion"),
+        ("PermisoImportacion", "PermisoImportacion"),
+        ("FolioImpoVUCEM", "FolioImpoVUCEM"),
+        ("NumCAS", "NumCAS"),
+        ("RazonSocialEmpImp", "RazonSocialEmpImp"),
+        ("NumRegSanPlagCOFEPRIS", "NumRegSanPlagCOFEPRIS"),
+        ("DatosFabricante", "DatosFabricante"),
+        ("DatosFormulador", "DatosFormulador"),
+        ("DatosMaquilador", "DatosMaquilador"),
+        ("UsoAutorizado", "UsoAutorizado"),
+        ("DescripcionMateria", "DescripcionMateria"),
+        ("UUIDComercioExt", "UUIDComercioExt"),
+    )
+    for src, dst in optional_str:
+        if mercancia.get(src) is not None:
+            mapped[dst] = str(mercancia[src])
+
+    optional_code = (
+        "MaterialPeligroso",
+        "CveMaterialPeligroso",
+        "Embalaje",
+        "SectorCOFEPRIS",
+        "FormaFarmaceutica",
+        "CondicionesEspTransp",
+        "Moneda",
+        "FraccionArancelaria",
+        "TipoMateria",
+    )
+    for key in optional_code:
+        _set_opt(mapped, key, _code_str(mercancia.get(key)))
+
+    if mercancia.get("FechaCaducidad") is not None:
+        mapped["FechaCaducidad"] = _format_date(mercancia["FechaCaducidad"], date_only=True)
+    if mercancia.get("ValorMercancia") is not None:
+        mapped["ValorMercancia"] = _num(mercancia["ValorMercancia"])
+    if docs := mercancia.get("DocumentacionAduanera"):
+        mapped["DocumentacionAduanera"] = _map_documentacion_aduanera(docs)
+    if guias := mercancia.get("GuiasIdentificacion"):
+        mapped["GuiasIdentificacion"] = _map_guias_identificacion(guias)
+    if cantidad := mercancia.get("CantidadTransporta"):
+        mapped["CantidadTransporta"] = _map_cantidad_transporta(cantidad)
+    if detalle := _map_detalle_mercancia(mercancia.get("DetalleMercancia")):
+        mapped["DetalleMercancia"] = detalle
+    return mapped
+
+
+def _map_remolques(remolques) -> list[dict]:
+    return [
+        {
+            "SubTipoRem": _code_str(remolque["SubTipoRem"]),
+            "Placa": str(remolque["Placa"]),
+        }
+        for remolque in iterate(remolques)
+    ]
+
+
+def _map_seguros(seguros) -> dict:
+    mapped: dict[str, Any] = {
+        "AseguraRespCivil": str(seguros["AseguraRespCivil"]),
+        "PolizaRespCivil": str(seguros["PolizaRespCivil"]),
+    }
+    _set_opt(
+        mapped,
+        "AseguraMedAmbiente",
+        seguros.get("AseguraMedAmbiente") and str(seguros["AseguraMedAmbiente"]),
+    )
+    _set_opt(
+        mapped,
+        "PolizaMedAmbiente",
+        seguros.get("PolizaMedAmbiente") and str(seguros["PolizaMedAmbiente"]),
+    )
+    _set_opt(
+        mapped,
+        "AseguraCarga",
+        seguros.get("AseguraCarga") and str(seguros["AseguraCarga"]),
+    )
+    _set_opt(
+        mapped,
+        "PolizaCarga",
+        seguros.get("PolizaCarga") and str(seguros["PolizaCarga"]),
+    )
+    if seguros.get("PrimaSeguro") is not None:
+        mapped["PrimaSeguro"] = _num(seguros["PrimaSeguro"])
+    return mapped
+
+
+def _map_identificacion_vehicular(ident) -> dict:
+    return {
+        "ConfigVehicular": _code_str(ident["ConfigVehicular"]),
+        "PesoBrutoVehicular": _num(ident["PesoBrutoVehicular"]),
+        "PlacaVM": str(ident["PlacaVM"]),
+        "AnioModeloVM": int(ident["AnioModeloVM"]),
+    }
+
+
+def _map_autotransporte(auto) -> dict:
+    mapped: dict[str, Any] = {
+        "PermSCT": _code_str(auto["PermSCT"]),
+        "NumPermisoSCT": str(auto["NumPermisoSCT"]),
+        "IdentificacionVehicular": _map_identificacion_vehicular(
+            auto["IdentificacionVehicular"]
+        ),
+        "Seguros": _map_seguros(auto["Seguros"]),
+    }
+    if remolques := auto.get("Remolques"):
+        mapped["Remolques"] = _map_remolques(remolques)
+    return mapped
+
+
+def _map_transporte_aereo(aereo) -> dict:
+    mapped: dict[str, Any] = {
+        "PermSCT": _code_str(aereo["PermSCT"]),
+        "NumPermisoSCT": str(aereo["NumPermisoSCT"]),
+        "NumeroGuia": str(aereo["NumeroGuia"]),
+        "CodigoTransportista": _code_str(aereo["CodigoTransportista"]),
+    }
+    for key in (
+        "MatriculaAeronave",
+        "NombreAseg",
+        "NumPolizaSeguro",
+        "LugarContrato",
+        "RFCEmbarcador",
+        "NumRegIdTribEmbarc",
+        "NombreEmbarcador",
+    ):
+        if aereo.get(key) is not None:
+            mapped[key] = str(aereo[key])
+    _set_opt(mapped, "ResidenciaFiscalEmbarc", _code_str(aereo.get("ResidenciaFiscalEmbarc")))
+    return mapped
+
+
+def _map_transporte_maritimo(maritimo) -> dict:
+    mapped: dict[str, Any] = {
+        "TipoEmbarcacion": _code_str(maritimo["TipoEmbarcacion"]),
+        "Matricula": str(maritimo["Matricula"]),
+        "NumeroOMI": str(maritimo["NumeroOMI"]),
+        "NacionalidadEmbarc": _code_str(maritimo["NacionalidadEmbarc"]),
+        "UnidadesDeArqBruto": _num(maritimo["UnidadesDeArqBruto"]),
+        "TipoCarga": _code_str(maritimo["TipoCarga"]),
+        "NombreAgenteNaviero": str(maritimo["NombreAgenteNaviero"]),
+        "NumAutorizacionNaviero": str(maritimo["NumAutorizacionNaviero"]),
+    }
+    for key in (
+        "PermSCT",
+        "NumPermisoSCT",
+        "NombreAseg",
+        "NumPolizaSeguro",
+        "NombreEmbarc",
+        "LineaNaviera",
+        "NumViaje",
+        "NumConocEmbarc",
+        "PermisoTempNavegacion",
+    ):
+        if maritimo.get(key) is not None:
+            if key == "PermSCT":
+                mapped[key] = _code_str(maritimo[key])
+            else:
+                mapped[key] = str(maritimo[key])
+    for key in ("AnioEmbarcacion",):
+        if maritimo.get(key) is not None:
+            mapped[key] = int(maritimo[key])
+    for key in ("Eslora", "Manga", "Calado", "Puntal"):
+        if maritimo.get(key) is not None:
+            mapped[key] = _num(maritimo[key])
+    if contenedores := maritimo.get("Contenedor"):
+        mapped["Contenedor"] = [
+            {
+                k: (_num(v) if k.startswith("Peso") else _code_str(v) if k == "TipoContenedor" else str(v))
+                for k, v in cont.items()
+                if v is not None
+            }
+            for cont in iterate(contenedores)
+        ]
+    return mapped
+
+
+def _map_transporte_ferroviario(ferro) -> dict:
+    mapped: dict[str, Any] = {
+        "TipoDeServicio": _code_str(ferro["TipoDeServicio"]),
+        "TipoDeTrafico": _code_str(ferro["TipoDeTrafico"]),
+        "Carro": [
+            {
+                "TipoCarro": _code_str(carro["TipoCarro"]),
+                "MatriculaCarro": str(carro["MatriculaCarro"]),
+                "GuiaCarro": str(carro["GuiaCarro"]),
+                "ToneladasNetasCarro": _num(carro["ToneladasNetasCarro"]),
+                **(
+                    {
+                        "Contenedor": [
+                            {
+                                "TipoContenedor": _code_str(c["TipoContenedor"]),
+                                "PesoContenedorVacio": _num(c["PesoContenedorVacio"]),
+                                "PesoNetoMercancia": _num(c["PesoNetoMercancia"]),
+                            }
+                            for c in iterate(carro["Contenedor"])
+                        ]
+                    }
+                    if carro.get("Contenedor")
+                    else {}
+                ),
+            }
+            for carro in iterate(ferro["Carro"])
+        ],
+    }
+    _set_opt(mapped, "NombreAseg", ferro.get("NombreAseg") and str(ferro["NombreAseg"]))
+    _set_opt(
+        mapped,
+        "NumPolizaSeguro",
+        ferro.get("NumPolizaSeguro") and str(ferro["NumPolizaSeguro"]),
+    )
+    if derechos := ferro.get("DerechosDePaso"):
+        mapped["DerechosDePaso"] = [
+            {
+                "TipoDerechoDePaso": _code_str(d["TipoDerechoDePaso"]),
+                "KilometrajePagado": _num(d["KilometrajePagado"]),
+            }
+            for d in iterate(derechos)
+        ]
+    return mapped
+
+
+def _map_mercancias(mercancias) -> dict:
+    mapped: dict[str, Any] = {
+        "PesoBrutoTotal": _num(mercancias["PesoBrutoTotal"]),
+        "UnidadPeso": _code_str(mercancias["UnidadPeso"]),
+        "NumTotalMercancias": int(mercancias["NumTotalMercancias"]),
+        "Mercancia": [_map_mercancia(m) for m in iterate(mercancias["Mercancia"])],
+    }
+    if mercancias.get("PesoNetoTotal") is not None:
+        mapped["PesoNetoTotal"] = _num(mercancias["PesoNetoTotal"])
+    if mercancias.get("CargoPorTasacion") is not None:
+        mapped["CargoPorTasacion"] = _num(mercancias["CargoPorTasacion"])
+    if mercancias.get("LogisticaInversaRecoleccionDevolucion") is not None:
+        mapped["LogisticaInversaRecoleccionDevolucion"] = str(
+            _enum_value(mercancias["LogisticaInversaRecoleccionDevolucion"])
+        )
+    if auto := mercancias.get("Autotransporte"):
+        mapped["Autotransporte"] = _map_autotransporte(auto)
+    if maritimo := mercancias.get("TransporteMaritimo"):
+        mapped["TransporteMaritimo"] = _map_transporte_maritimo(maritimo)
+    if aereo := mercancias.get("TransporteAereo"):
+        mapped["TransporteAereo"] = _map_transporte_aereo(aereo)
+    if ferro := mercancias.get("TransporteFerroviario"):
+        mapped["TransporteFerroviario"] = _map_transporte_ferroviario(ferro)
+    return mapped
+
+
+def _map_figura_transporte(figura) -> dict:
+    mapped: dict[str, Any] = {
+        "TipoFigura": _code_str(figura["TipoFigura"]),
+        "NombreFigura": str(figura["NombreFigura"]),
+    }
+    _set_opt(mapped, "RFCFigura", figura.get("RFCFigura") and str(figura["RFCFigura"]))
+    _set_opt(mapped, "NumLicencia", figura.get("NumLicencia") and str(figura["NumLicencia"]))
+    _set_opt(
+        mapped,
+        "NumRegIdTribFigura",
+        figura.get("NumRegIdTribFigura") and str(figura["NumRegIdTribFigura"]),
+    )
+    _set_opt(
+        mapped,
+        "ResidenciaFiscalFigura",
+        _code_str(figura.get("ResidenciaFiscalFigura")),
+    )
+    if partes := figura.get("PartesTransporte"):
+        mapped["PartesTransporte"] = _map_partes_transporte(partes)
+    if domicilio := _map_domicilio(figura.get("Domicilio")):
+        mapped["Domicilio"] = domicilio
+    return mapped
+
+
+def _map_carta_porte(carta) -> dict:
+    """Map satcfdi Carta Porte 3.1 to Facturama ``CartaPorte31`` JSON."""
+    version = str(carta.get("Version") or "3.1")
+    if version != "3.1":
+        raise NotImplementedError(
+            f"Facturama Multiemisor adapter supports Carta Porte 3.1 only, got {version!r}"
+        )
+
+    mapped: dict[str, Any] = {
+        "TranspInternac": str(_enum_value(carta["TranspInternac"])),
+        "Ubicaciones": [_map_ubicacion(u) for u in iterate(carta["Ubicaciones"])],
+        "Mercancias": _map_mercancias(carta["Mercancias"]),
+    }
+    if carta.get("IdCCP") is not None:
+        mapped["IdCCP"] = str(carta["IdCCP"])
+    if carta.get("EntradaSalidaMerc") is not None:
+        mapped["EntradaSalidaMerc"] = str(_enum_value(carta["EntradaSalidaMerc"]))
+    _set_opt(mapped, "PaisOrigenDestino", _code_str(carta.get("PaisOrigenDestino")))
+    _set_opt(mapped, "ViaEntradaSalida", _code_str(carta.get("ViaEntradaSalida")))
+    if carta.get("TotalDistRec") is not None:
+        mapped["TotalDistRec"] = _num(carta["TotalDistRec"])
+    if carta.get("RegistroISTMO") is not None:
+        mapped["RegistroISTMO"] = str(_enum_value(carta["RegistroISTMO"]))
+    _set_opt(mapped, "UbicacionPoloOrigen", _code_str(carta.get("UbicacionPoloOrigen")))
+    _set_opt(mapped, "UbicacionPoloDestino", _code_str(carta.get("UbicacionPoloDestino")))
+    if regimenes := carta.get("RegimenesAduaneros"):
+        mapped["RegimenesAduaneros"] = _map_regimenes_aduaneros(regimenes)
+    if figuras := carta.get("FiguraTransporte"):
+        mapped["FiguraTransporte"] = [
+            _map_figura_transporte(f) for f in iterate(figuras)
+        ]
+    return mapped
+
+
+def _format_donation_date(fecha) -> str:
+    """Facturama Donation uses DD/MM/YYYY."""
+    if isinstance(fecha, datetime):
+        return fecha.strftime("%d/%m/%Y")
+    if isinstance(fecha, date):
+        return fecha.strftime("%d/%m/%Y")
+    text = str(fecha)
+    if len(text) >= 10 and text[4] == "-":
+        # YYYY-MM-DD -> DD/MM/YYYY
+        return f"{text[8:10]}/{text[5:7]}/{text[0:4]}"
+    return text
+
+
+def _map_donation(donat) -> dict:
+    return {
+        "AuthorizationDate": _format_donation_date(donat["FechaAutorizacion"]),
+        "AuthorizationNumber": str(donat["NoAutorizacion"]),
+        "Legend": str(donat["Leyenda"]),
+    }
+
+
+def _map_tax_legends(leyendas) -> dict:
+    legends = []
+    for leyenda in iterate(leyendas.get("Leyenda")):
+        entry: dict[str, Any] = {"Text": str(leyenda["TextoLeyenda"])}
+        _set_opt(
+            entry,
+            "TaxProvision",
+            leyenda.get("DisposicionFiscal") and str(leyenda["DisposicionFiscal"]),
+        )
+        _set_opt(entry, "Norm", leyenda.get("Norma") and str(leyenda["Norma"]))
+        legends.append(entry)
+    return {"Legends": legends}
+
+
+def _local_tax_entries(implocal) -> list[dict]:
+    """
+    Facturama has no ImpuestosLocales complement node; local taxes go on item
+    Taxes with IsFederalTax=false (see API Web factura guide).
+    """
+    taxes = []
+    for ret in iterate(implocal.get("RetencionesLocales")):
+        taxes.append(
+            {
+                "Name": str(ret["ImpLocRetenido"]),
+                "Rate": _num(ret["TasadeRetencion"]),
+                "Total": _num(ret["Importe"]) or 0.0,
+                "Base": 0.0,
+                "IsRetention": True,
+                "IsQuota": False,
+                "IsFederalTax": False,
+            }
+        )
+    for tras in iterate(implocal.get("TrasladosLocales")):
+        taxes.append(
+            {
+                "Name": str(tras["ImpLocTrasladado"]),
+                "Rate": _num(tras["TasadeTraslado"]),
+                "Total": _num(tras["Importe"]) or 0.0,
+                "Base": 0.0,
+                "IsRetention": False,
+                "IsQuota": False,
+                "IsFederalTax": False,
+            }
+        )
+    return taxes
+
+
+def _apply_local_taxes_to_items(items: list[dict], implocal) -> None:
+    local_taxes = _local_tax_entries(implocal)
+    if not local_taxes or not items:
+        return
+    # Facturama models local taxes at item level; attach to the first concept.
+    first = items[0]
+    taxes = list(first.get("Taxes") or [])
+    taxes.extend(local_taxes)
+    first["Taxes"] = taxes
+    line_total = first.get("Total") or 0.0
+    for tax in local_taxes:
+        if tax["IsRetention"]:
+            line_total -= tax["Total"] or 0.0
+        else:
+            line_total += tax["Total"] or 0.0
+    first["Total"] = line_total
+
+
+def _map_foreign_trade_address(domicilio) -> dict | None:
+    if not domicilio:
+        return None
+    mapped: dict[str, Any] = {}
+    _set_opt(mapped, "Street", domicilio.get("Calle") and str(domicilio["Calle"]))
+    _set_opt(
+        mapped,
+        "ExteriorNumber",
+        domicilio.get("NumeroExterior") and str(domicilio["NumeroExterior"]),
+    )
+    _set_opt(
+        mapped,
+        "InteriorNumber",
+        domicilio.get("NumeroInterior") and str(domicilio["NumeroInterior"]),
+    )
+    _set_opt(mapped, "Neighborhood", _code_str(domicilio.get("Colonia")))
+    _set_opt(
+        mapped,
+        "Reference",
+        domicilio.get("Referencia") and str(domicilio["Referencia"]),
+    )
+    _set_opt(mapped, "Locality", _code_str(domicilio.get("Localidad")))
+    _set_opt(mapped, "Municipality", _code_str(domicilio.get("Municipio")))
+    _set_opt(mapped, "State", _code_str(domicilio.get("Estado")))
+    _set_opt(mapped, "Country", _code_str(domicilio.get("Pais")))
+    _set_opt(
+        mapped,
+        "ZipCode",
+        domicilio.get("CodigoPostal") and str(domicilio["CodigoPostal"]),
+    )
+    return mapped or None
+
+
+def _map_foreign_trade(cce) -> dict:
+    version = str(cce.get("Version") or "2.0")
+    if not version.startswith("2"):
+        raise NotImplementedError(
+            f"Facturama ForeignTrade mapper supports ComercioExterior 2.x, got {version!r}"
+        )
+
+    mapped: dict[str, Any] = {
+        "RequestCode": _code_str(cce["ClaveDePedimento"]),
+        "ExchangeRateUSD": _num(cce["TipoCambioUSD"]),
+        "TotalUSD": _num(cce["TotalUSD"]),
+    }
+    cert = cce.get("CertificadoOrigen")
+    if cert is not None:
+        mapped["OriginCertificate"] = bool(int(cert)) if not isinstance(cert, bool) else cert
+    _set_opt(mapped, "OriginCertificateNumber", cce.get("NumCertificadoOrigen") and str(cce["NumCertificadoOrigen"]))
+    _set_opt(
+        mapped,
+        "ReliableExporterNumber",
+        cce.get("NumeroExportadorConfiable") and str(cce["NumeroExportadorConfiable"]),
+    )
+    _set_opt(mapped, "Incoterm", _code_str(cce.get("Incoterm")))
+    _set_opt(mapped, "Observations", cce.get("Observaciones") and str(cce["Observaciones"]))
+    _set_opt(mapped, "ReasonForTrasnfer", _code_str(cce.get("MotivoTraslado")))
+
+    if emisor := cce.get("Emisor"):
+        issuer: dict[str, Any] = {}
+        if addr := _map_foreign_trade_address(emisor.get("Domicilio")):
+            issuer["Address"] = addr
+        _set_opt(issuer, "Curp", emisor.get("Curp") and str(emisor["Curp"]))
+        if issuer:
+            mapped["Issuer"] = issuer
+
+    if receptor := cce.get("Receptor"):
+        receiver: dict[str, Any] = {}
+        if addr := _map_foreign_trade_address(receptor.get("Domicilio")):
+            receiver["Address"] = addr
+        _set_opt(
+            receiver,
+            "NumRegIdTrib",
+            receptor.get("NumRegIdTrib") and str(receptor["NumRegIdTrib"]),
+        )
+        if receiver:
+            mapped["Receiver"] = receiver
+
+    if propietarios := cce.get("Propietario"):
+        mapped["Owner"] = [
+            {
+                "NumRegIdTrib": str(p["NumRegIdTrib"]),
+                "TaxResidence": _code_str(p["ResidenciaFiscal"]),
+            }
+            for p in iterate(propietarios)
+        ]
+
+    if destinatarios := cce.get("Destinatario"):
+        recipients = []
+        for dest in iterate(destinatarios):
+            entry: dict[str, Any] = {}
+            _set_opt(entry, "NumRegIdTrib", dest.get("NumRegIdTrib") and str(dest["NumRegIdTrib"]))
+            _set_opt(entry, "Name", dest.get("Nombre") and str(dest["Nombre"]))
+            addresses = [
+                addr
+                for d in iterate(dest.get("Domicilio"))
+                if (addr := _map_foreign_trade_address(d))
+            ]
+            if addresses:
+                entry["Address"] = addresses
+            recipients.append(entry)
+        mapped["Recipient"] = recipients
+
+    commodities = []
+    for merc in iterate(cce.get("Mercancias") or cce.get("Mercancia")):
+        # after create(): Mercancias may be list; key is Mercancias holding Sequence
+        commodity: dict[str, Any] = {
+            "IdentificationNumber": str(merc["NoIdentificacion"]),
+            "ValueInDolar": _num(merc["ValorDolares"]),
+        }
+        _set_opt(commodity, "TariffFraction", _code_str(merc.get("FraccionArancelaria")))
+        if merc.get("CantidadAduana") is not None:
+            commodity["CustomsQuantity"] = str(_num(merc["CantidadAduana"]))
+        _set_opt(commodity, "CustomsUnit", _code_str(merc.get("UnidadAduana")))
+        if merc.get("ValorUnitarioAduana") is not None:
+            commodity["CustomsUnitValue"] = _num(merc["ValorUnitarioAduana"])
+        if specs := merc.get("DescripcionesEspecificas"):
+            commodity["SpecificDescriptions"] = [
+                {
+                    "Brand": str(s["Marca"]),
+                    **(
+                        {"Model": str(s["Modelo"])}
+                        if s.get("Modelo") is not None
+                        else {}
+                    ),
+                    **(
+                        {"SubModel": str(s["SubModelo"])}
+                        if s.get("SubModelo") is not None
+                        else {}
+                    ),
+                    **(
+                        {"SerialNumber": str(s["NumeroSerie"])}
+                        if s.get("NumeroSerie") is not None
+                        else {}
+                    ),
+                }
+                for s in iterate(specs)
+            ]
+        commodities.append(commodity)
+    if commodities:
+        mapped["Commodity"] = commodities
+    return mapped
+
+
+def _apply_item_complements(
+    cfdi: CFDI,
+    payload: dict,
+    *,
+    allow_foreign_trade: bool = False,
+) -> None:
+    complemento_out: dict[str, Any] = {}
+
+    if carta := _complement_node(cfdi, "CartaPorte"):
+        payload["NameId"] = _CARTA_PORTE_NAME_ID
+        complemento_out["CartaPorte31"] = _map_carta_porte(carta)
+
+    if donat := _complement_node(cfdi, "Donatarias"):
+        payload["NameId"] = _DONATION_NAME_ID
+        complemento_out["Donation"] = _map_donation(donat)
+
+    if leyendas := _complement_node(cfdi, "LeyendasFiscales"):
+        complemento_out["TaxLegends"] = _map_tax_legends(leyendas)
+
+    if implocal := _complement_node(cfdi, "ImpuestosLocales"):
+        _apply_local_taxes_to_items(payload["Items"], implocal)
+
+    if cce := _complement_node(cfdi, "ComercioExterior"):
+        if not allow_foreign_trade:
+            raise NotImplementedError(
+                "Facturama Multiemisor does not support Comercio Exterior; "
+                "use FacturamaWeb (API Web)."
+            )
+        payload["NameId"] = _FOREIGN_TRADE_NAME_ID
+        complemento_out["ForeignTrade"] = _map_foreign_trade(cce)
+
+    if complemento_out:
+        payload["Complemento"] = complemento_out
+
+    complemento = cfdi.get("Complemento") or {}
+    if isinstance(complemento, Mapping) and not _is_known_item_complement_body(complemento):
+        unsupported = {k for k in complemento if k not in _ITEM_COMPLEMENT_KEYS}
+        if unsupported:
+            raise NotImplementedError(
+                f"Unsupported Complemento nodes for item CFDI mapper: {sorted(unsupported)}"
+            )
 
 
 def _uuid_from_relacionado(uuid_node) -> str:
@@ -446,6 +1285,10 @@ def _base_payload(cfdi: CFDI, tipo: str) -> dict:
             "TaxZipCode": str(receptor["DomicilioFiscalReceptor"]),
         },
     }
+    if num_reg := receptor.get("NumRegIdTrib"):
+        payload["Receiver"]["TaxRegistrationNumber"] = str(num_reg)
+    if residencia := receptor.get("ResidenciaFiscal"):
+        payload["Receiver"]["TaxResidence"] = _code_str(residencia)
     if fecha := _format_date(cfdi.get("Fecha")):
         payload["Date"] = fecha
     if serie := cfdi.get("Serie"):
@@ -467,8 +1310,15 @@ def _base_payload(cfdi: CFDI, tipo: str) -> dict:
     return payload
 
 
-def cfdi_to_facturama_payload(cfdi: CFDI) -> dict:
-    """Map a satcfdi CFDI (typically unsigned) to Facturama Multiemisor JSON."""
+def cfdi_to_facturama_payload(
+    cfdi: CFDI,
+    *,
+    allow_foreign_trade: bool = False,
+) -> dict:
+    """Map a satcfdi CFDI (typically unsigned) to Facturama JSON.
+
+    :param allow_foreign_trade: Enable Comercio Exterior mapping (API Web only).
+    """
     if not isinstance(cfdi, CFDI):
         raise TypeError("cfdi must be a CFDI object")
 
@@ -495,18 +1345,11 @@ def cfdi_to_facturama_payload(cfdi: CFDI) -> dict:
         if condiciones := cfdi.get("CondicionesDePago"):
             payload["PaymentConditions"] = str(condiciones)
         payload["Items"] = _map_items(cfdi)
-
-        unsupported = set()
-        complemento = cfdi.get("Complemento") or {}
-        if isinstance(complemento, dict):
-            unsupported = {
-                k for k in complemento
-                if k not in {"TimbreFiscalDigital", "Pagos", "Nomina", "Pago"}
-            }
-        if unsupported:
-            raise NotImplementedError(
-                f"Unsupported Complemento nodes for item CFDI mapper: {sorted(unsupported)}"
-            )
+        _apply_item_complements(
+            cfdi,
+            payload,
+            allow_foreign_trade=allow_foreign_trade,
+        )
         return payload
 
     if tipo == "P":
@@ -543,11 +1386,18 @@ class Facturama(PAC):
     Facturama is a billing platform that seals+stamps via Multiemisor; CSD files
     must be uploaded first (see :meth:`upload_csd`).
 
+    Comercio exterior is not available on Multiemisor; use :class:`FacturamaWeb`.
+
     Documentation: https://apisandbox.facturama.mx/guias/api-multi/proceso-facturacion
     """
 
     # Facturama aggregates multiple PACs; no single PAC RFC applies.
     RFC = None
+    _issue_path = "api-lite/3/cfdis"
+    _download_type = "issuedLite"
+    _cancel_path_prefix = "api-lite/cfdis"
+    _list_path = "api-lite/cfdis"
+    _allow_foreign_trade = False
 
     def __init__(self, username: str, password: str, environment=Environment.PRODUCTION):
         super().__init__(environment=environment)
@@ -595,7 +1445,7 @@ class Facturama(PAC):
     def _download_file(self, document_id: str, fmt: str) -> bytes:
         res = self._request(
             "get",
-            f"api/Cfdi/{fmt}/issuedLite/{document_id}",
+            f"api/Cfdi/{fmt}/{self._download_type}/{document_id}",
         )
         if isinstance(res, dict) and "Content" in res:
             return base64.urlsafe_b64decode(res["Content"].encode("utf-8"))
@@ -631,11 +1481,13 @@ class Facturama(PAC):
         return self._request("get", f"api-lite/csds/{rfc.upper()}")
 
     def list_cfdis(self, *, keyword: str | None = None, status: str = "all") -> list[dict]:
-        """List Multiemisor CFDIs (optionally filtered by keyword / UUID)."""
+        """List CFDIs (optionally filtered by keyword / UUID)."""
         params = {"status": status}
         if keyword:
             params["keyword"] = keyword
-        results = self._request("get", "api-lite/cfdis", params=params)
+        if self._list_path == "api/Cfdi":
+            params["type"] = "issued"
+        results = self._request("get", self._list_path, params=params)
         if results is None:
             return []
         if isinstance(results, list):
@@ -657,13 +1509,16 @@ class Facturama(PAC):
 
     def issue(self, cfdi: CFDI, accept: Accept = Accept.XML) -> Document:
         """
-        Seal and stamp via Facturama Multiemisor.
+        Seal and stamp via Facturama.
 
         The local CFDI does not need to be signed; Facturama seals with the
-        uploaded CSD for the issuer RFC.
+        uploaded CSD (Multiemisor) or account fiscal profile (API Web).
         """
-        payload = cfdi_to_facturama_payload(cfdi)
-        created = self._request("post", "api-lite/3/cfdis", json=payload)
+        payload = cfdi_to_facturama_payload(
+            cfdi,
+            allow_foreign_trade=self._allow_foreign_trade,
+        )
+        created = self._request("post", self._issue_path, json=payload)
         document_id = created["Id"]
 
         xml = None
@@ -677,7 +1532,7 @@ class Facturama(PAC):
 
     def stamp(self, cfdi: CFDI, accept: Accept = Accept.XML) -> Document:
         raise NotImplementedError(
-            "Facturama Multiemisor does not stamp pre-signed XML; use issue() "
+            "Facturama does not stamp pre-signed XML; use issue() "
             "(Facturama seals and stamps from the mapped JSON payload)."
         )
 
@@ -689,6 +1544,21 @@ class Facturama(PAC):
     def recover_by_uuid(self, uuid: str, accept: Accept = Accept.XML) -> Document:
         return self.recover(self.find_id_by_uuid(uuid), accept=accept)
 
+    def send_email(self, document_id: str, email: str, *, cfdi_type: str | None = None) -> dict | None:
+        """Send a stamped CFDI by email through Facturama."""
+        cfdi_type = cfdi_type or (
+            "issuedLite" if self._download_type == "issuedLite" else "issued"
+        )
+        return self._request(
+            "post",
+            "api/Cfdi",
+            params={
+                "cfdiType": cfdi_type,
+                "cfdiId": document_id,
+                "email": email,
+            },
+        )
+
     def cancel(
         self,
         cfdi: CFDI,
@@ -698,7 +1568,7 @@ class Facturama(PAC):
         document_id: str = None,
     ) -> CancelationAcknowledgment:
         """
-        Cancel a Multiemisor CFDI.
+        Cancel a Facturama CFDI.
 
         Resolves Facturama Id from ``document_id`` or from the CFDI UUID
         (``Complemento.TimbreFiscalDigital.UUID``) via :meth:`find_id_by_uuid`.
@@ -713,10 +1583,12 @@ class Facturama(PAC):
         params = {"motive": reason.value}
         if substitution_id:
             params["uuidReplacement"] = substitution_id
+        if self._cancel_path_prefix == "api/Cfdi":
+            params["type"] = "issued"
 
         res = self._request(
             "delete",
-            f"api-lite/cfdis/{facturama_id}",
+            f"{self._cancel_path_prefix}/{facturama_id}",
             params=params,
         )
         status = None
@@ -730,3 +1602,39 @@ class Facturama(PAC):
                     except Exception:
                         acuse = content.encode() if content else None
         return CancelationAcknowledgment(code=status or "cancelled", acuse=acuse)
+
+
+class FacturamaWeb(Facturama):
+    """
+    Facturama API Web adapter (single-issuer account fiscal profile).
+
+    Unlike Multiemisor, API Web does not require per-RFC CSD upload via
+    :meth:`upload_csd` (CSD lives on the Facturama account). It is also the
+    only Facturama mode that supports Comercio Exterior.
+
+    Documentation: https://apisandbox.facturama.mx/guias/api-web/cfdi/factura
+    """
+
+    _issue_path = "api/3/cfdis"
+    _download_type = "issued"
+    _cancel_path_prefix = "api/Cfdi"
+    _list_path = "api/Cfdi"
+    _allow_foreign_trade = True
+
+    def upload_csd(self, rfc: str, certificate: bytes, key: bytes, password: str | bytes) -> dict:
+        raise NotImplementedError(
+            "FacturamaWeb uses the account fiscal profile CSD; "
+            "upload certificates in the Facturama web UI, or use Facturama Multiemisor."
+        )
+
+    def delete_csd(self, rfc: str) -> None:
+        raise NotImplementedError(
+            "FacturamaWeb uses the account fiscal profile CSD; "
+            "manage certificates in the Facturama web UI."
+        )
+
+    def get_csd(self, rfc: str) -> dict:
+        raise NotImplementedError(
+            "FacturamaWeb uses the account fiscal profile CSD; "
+            "manage certificates in the Facturama web UI."
+        )

--- a/tests/test_pac_facturama.py
+++ b/tests/test_pac_facturama.py
@@ -5,10 +5,10 @@ from unittest import mock
 
 from requests.auth import HTTPBasicAuth
 
-from satcfdi.create.cfd import cfdi40, nomina12, pago20
+from satcfdi.create.cfd import cfdi40, nomina12, pago20, donat11, leyendasFisc10, implocal10, cce20
 from satcfdi.create.cfd.catalogos import Impuesto, TipoFactor
 from satcfdi.pacs import Accept, CancelReason, Environment
-from satcfdi.pacs.facturama import Facturama, cfdi_to_facturama_payload
+from satcfdi.pacs.facturama import Facturama, FacturamaWeb, cfdi_to_facturama_payload
 from .utils import get_signer, verify_result
 
 
@@ -370,6 +370,467 @@ def test_cfdi_to_facturama_payload_traslado():
     payload = cfdi_to_facturama_payload(invoice)
     assert payload["CfdiType"] == "T"
     assert payload["Items"][0]["ProductCode"] == "24111506"
+
+
+def _sample_carta_porte_traslado():
+    from satcfdi.create.cfd import cartaporte31 as cp
+
+    signer = get_signer("xiqb891116qe4")
+    carta = cp.CartaPorte(
+        id_ccp="CCCBB0A0-A0A0-0A00-000A-0A0A000A000A",
+        transp_internac="No",
+        total_dist_rec=Decimal("120.5"),
+        ubicaciones=[
+            cp.Ubicacion(
+                tipo_ubicacion="Origen",
+                rfc_remitente_destinatario=signer.rfc,
+                fecha_hora_salida_llegada=datetime.fromisoformat("2022-05-16T15:15:00"),
+                id_ubicacion="OR000001",
+                domicilio=cp.Domicilio(
+                    estado="SLP",
+                    pais="MEX",
+                    codigo_postal="78000",
+                    municipio="028",
+                    localidad="05",
+                ),
+            ),
+            cp.Ubicacion(
+                tipo_ubicacion="Destino",
+                rfc_remitente_destinatario="URE180429TM6",
+                fecha_hora_salida_llegada=datetime.fromisoformat("2022-05-16T18:15:00"),
+                id_ubicacion="DE000001",
+                distancia_recorrida=Decimal("120.5"),
+                domicilio=cp.Domicilio(
+                    estado="SLP",
+                    pais="MEX",
+                    codigo_postal="78000",
+                    municipio="028",
+                    localidad="05",
+                ),
+            ),
+        ],
+        mercancias=cp.Mercancias(
+            peso_bruto_total=Decimal("1"),
+            unidad_peso="KGM",
+            num_total_mercancias=1,
+            mercancia=cp.Mercancia(
+                bienes_transp="11121900",
+                descripcion="Accesorios de equipo de telefonía",
+                cantidad=Decimal("1"),
+                clave_unidad="XBX",
+                peso_en_kg=Decimal("1"),
+                material_peligroso="No",
+                cantidad_transporta=cp.CantidadTransporta(
+                    cantidad=Decimal("1"),
+                    id_origen="OR000001",
+                    id_destino="DE000001",
+                ),
+            ),
+            autotransporte=cp.Autotransporte(
+                perm_sct="TPAF01",
+                num_permiso_sct="NumPermisoSCT1",
+                identificacion_vehicular=cp.IdentificacionVehicular(
+                    config_vehicular="VL",
+                    peso_bruto_vehicular=Decimal("1"),
+                    placa_vm="ABC1234",
+                    anio_modelo_vm=2020,
+                ),
+                seguros=cp.Seguros(
+                    asegura_resp_civil="AseguraRespCivil",
+                    poliza_resp_civil="123456789",
+                ),
+                remolques=cp.Remolque(sub_tipo_rem="CTR004", placa="VL45K98"),
+            ),
+        ),
+        figura_transporte=cp.TiposFigura(
+            tipo_figura="01",
+            nombre_figura="Operador Uno",
+            rfc_figura="EKU9003173C9",
+            num_licencia="NumLicencia1",
+            domicilio=cp.Domicilio(
+                estado="SLP",
+                pais="MEX",
+                codigo_postal="78000",
+                calle="Calle1",
+                numero_exterior="100",
+            ),
+        ),
+    )
+    return cfdi40.Comprobante(
+        emisor=cfdi40.Emisor(
+            rfc=signer.rfc,
+            nombre=signer.legal_name,
+            regimen_fiscal="601",
+        ),
+        lugar_expedicion="78000",
+        fecha=datetime.fromisoformat("2022-05-16T15:00:00"),
+        receptor=cfdi40.Receptor(
+            rfc="URE180429TM6",
+            nombre="UNIVERSIDAD ROBOTICA ESPAÑOLA",
+            uso_cfdi="S01",
+            domicilio_fiscal_receptor="65000",
+            regimen_fiscal_receptor="601",
+        ),
+        tipo_de_comprobante="T",
+        exportacion="01",
+        serie="CP",
+        folio="1",
+        conceptos=cfdi40.Concepto(
+            clave_prod_serv="24111506",
+            cantidad=Decimal("1"),
+            clave_unidad="H87",
+            descripcion="MERCANCIA EN TRASLADO",
+            valor_unitario=Decimal("0"),
+            objeto_imp="01",
+        ),
+        complemento=carta,
+    )
+
+
+def test_cfdi_to_facturama_payload_carta_porte():
+    payload = cfdi_to_facturama_payload(_sample_carta_porte_traslado())
+    verify = verify_result(
+        data=json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True),
+        filename="test_payload_carta_porte.json",
+    )
+    assert verify
+    assert payload["CfdiType"] == "T"
+    assert payload["NameId"] == "36"
+    cp = payload["Complemento"]["CartaPorte31"]
+    assert cp["TranspInternac"] == "No"
+    assert cp["IdCCP"] == "CCCBB0A0-A0A0-0A00-000A-0A0A000A000A"
+    assert len(cp["Ubicaciones"]) == 2
+    assert cp["Ubicaciones"][0]["FechaHoraSalidaLlegada"] == "2022-05-16 15:15:00"
+    assert cp["Mercancias"]["Autotransporte"]["PermSCT"] == "TPAF01"
+    assert cp["Mercancias"]["Autotransporte"]["Remolques"][0]["Placa"] == "VL45K98"
+    assert cp["Mercancias"]["Mercancia"][0]["CantidadTransporta"][0]["IDOrigen"] == (
+        "OR000001"
+    )
+    assert cp["FiguraTransporte"][0]["TipoFigura"] == "01"
+    assert cp["FiguraTransporte"][0]["NumLicencia"] == "NumLicencia1"
+
+
+def test_cfdi_to_facturama_payload_carta_porte_nested_key():
+    """Complemento as dict with CartaPorte key (XML-parsed shape)."""
+    invoice = _sample_carta_porte_traslado()
+    carta = invoice["Complemento"]
+    invoice["Complemento"] = {"CartaPorte": carta}
+    payload = cfdi_to_facturama_payload(invoice)
+    assert payload["NameId"] == "36"
+    assert payload["Complemento"]["CartaPorte31"]["TranspInternac"] == "No"
+    assert payload["Complemento"]["CartaPorte31"]["Mercancias"]["NumTotalMercancias"] == 1
+
+
+def test_cfdi_to_facturama_payload_carta_porte_partes_transporte():
+    from satcfdi.create.cfd import cartaporte31 as cp
+
+    invoice = _sample_carta_porte_traslado()
+    invoice["Complemento"]["FiguraTransporte"] = cp.TiposFigura(
+        tipo_figura="02",
+        nombre_figura="Propietario",
+        rfc_figura="EKU9003173C9",
+        partes_transporte=["PT01", "PT02"],
+    )
+    payload = cfdi_to_facturama_payload(invoice)
+    figura = payload["Complemento"]["CartaPorte31"]["FiguraTransporte"][0]
+    assert figura["PartesTransporte"] == [
+        {"ParteTransporte": "PT01"},
+        {"ParteTransporte": "PT02"},
+    ]
+
+
+def test_cfdi_to_facturama_payload_donation():
+    signer = get_signer("xiqb891116qe4")
+    invoice = cfdi40.Comprobante(
+        emisor=cfdi40.Emisor(
+            rfc=signer.rfc,
+            nombre=signer.legal_name,
+            regimen_fiscal="601",
+        ),
+        lugar_expedicion="51873",
+        fecha=datetime.fromisoformat("2019-06-19T13:45:00"),
+        receptor=cfdi40.Receptor(
+            rfc="MISC491214B86",
+            nombre="CECILIA MIRANDA SANCHEZ",
+            uso_cfdi="D04",
+            domicilio_fiscal_receptor="65010",
+            regimen_fiscal_receptor="605",
+        ),
+        forma_pago="12",
+        metodo_pago="PUE",
+        serie="D",
+        folio="94",
+        conceptos=cfdi40.Concepto(
+            clave_prod_serv="20102000",
+            cantidad=Decimal("3"),
+            clave_unidad="EA",
+            descripcion="Cobija de lana y algodon",
+            valor_unitario=Decimal("1000"),
+            objeto_imp="01",
+        ),
+        complemento=donat11.Donatarias(
+            no_autorizacion="B400-05-08-2014-005",
+            fecha_autorizacion=date(2019, 1, 30),
+            leyenda="El comprobante es un donativo",
+        ),
+    )
+    payload = cfdi_to_facturama_payload(invoice)
+    verify = verify_result(
+        data=json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True),
+        filename="test_payload_donation.json",
+    )
+    assert verify
+    assert payload["NameId"] == "9"
+    assert payload["Complemento"]["Donation"] == {
+        "AuthorizationDate": "30/01/2019",
+        "AuthorizationNumber": "B400-05-08-2014-005",
+        "Legend": "El comprobante es un donativo",
+    }
+
+
+def test_cfdi_to_facturama_payload_tax_legends():
+    signer = get_signer("xiqb891116qe4")
+    invoice = cfdi40.Comprobante(
+        emisor=cfdi40.Emisor(
+            rfc=signer.rfc,
+            nombre=signer.legal_name,
+            regimen_fiscal="601",
+        ),
+        lugar_expedicion="78116",
+        fecha=datetime.fromisoformat("2022-09-28T22:40:38"),
+        receptor=cfdi40.Receptor(
+            rfc="URE180429TM6",
+            nombre="UNIVERSIDAD ROBOTICA ESPAÑOLA",
+            uso_cfdi="G03",
+            domicilio_fiscal_receptor="65000",
+            regimen_fiscal_receptor="601",
+        ),
+        forma_pago="01",
+        metodo_pago="PUE",
+        conceptos=cfdi40.Concepto(
+            clave_prod_serv="20102001",
+            cantidad=Decimal("1"),
+            clave_unidad="E48",
+            descripcion="Servicio",
+            valor_unitario=Decimal("100"),
+            objeto_imp="01",
+        ),
+        complemento=leyendasFisc10.LeyendasFiscales(
+            leyenda=leyendasFisc10.Leyenda(
+                texto_leyenda="EXPORTADOR #####",
+                disposicion_fiscal="ISR",
+                norma="Art22",
+            )
+        ),
+    )
+    payload = cfdi_to_facturama_payload(invoice)
+    assert payload["Complemento"]["TaxLegends"]["Legends"] == [
+        {"TaxProvision": "ISR", "Norm": "Art22", "Text": "EXPORTADOR #####"}
+    ]
+
+
+def test_cfdi_to_facturama_payload_impuestos_locales():
+    signer = get_signer("xiqb891116qe4")
+    invoice = cfdi40.Comprobante(
+        emisor=cfdi40.Emisor(
+            rfc=signer.rfc,
+            nombre=signer.legal_name,
+            regimen_fiscal="601",
+        ),
+        lugar_expedicion="27200",
+        fecha=datetime.fromisoformat("2022-09-28T22:40:38"),
+        receptor=cfdi40.Receptor(
+            rfc="URE180429TM6",
+            nombre="UNIVERSIDAD ROBOTICA ESPAÑOLA",
+            uso_cfdi="G03",
+            domicilio_fiscal_receptor="65000",
+            regimen_fiscal_receptor="601",
+        ),
+        forma_pago="01",
+        metodo_pago="PUE",
+        conceptos=cfdi40.Concepto(
+            clave_prod_serv="90111501",
+            cantidad=Decimal("1"),
+            clave_unidad="E48",
+            descripcion="Hospedaje",
+            valor_unitario=Decimal("1000"),
+            impuestos=cfdi40.Impuestos(
+                traslados=cfdi40.Traslado(
+                    impuesto=Impuesto.IVA,
+                    tipo_factor=TipoFactor.TASA,
+                    tasa_o_cuota=Decimal("0.160000"),
+                ),
+            ),
+        ),
+        complemento=implocal10.ImpuestosLocales(
+            total_de_retenciones=Decimal("0"),
+            total_de_traslados=Decimal("40"),
+            traslados_locales=implocal10.TrasladosLocales(
+                imp_loc_trasladado="IMPUESTO DE HOSPEDAJE",
+                tasa_de_traslado=Decimal("4.00"),
+                importe=Decimal("40.00"),
+            ),
+        ),
+    )
+    payload = cfdi_to_facturama_payload(invoice)
+    taxes = payload["Items"][0]["Taxes"]
+    assert taxes[0]["IsFederalTax"] is True
+    assert taxes[0]["Name"] == "IVA"
+    assert taxes[1] == {
+        "Name": "IMPUESTO DE HOSPEDAJE",
+        "Rate": 4.0,
+        "Total": 40.0,
+        "Base": 0.0,
+        "IsRetention": False,
+        "IsQuota": False,
+        "IsFederalTax": False,
+    }
+    assert payload["Items"][0]["Total"] == 1200.0  # 1000 + 160 IVA + 40 local
+
+
+def test_cfdi_to_facturama_payload_foreign_trade_requires_web():
+    signer = get_signer("xiqb891116qe4")
+    cce = cce20.ComercioExterior(
+        clave_de_pedimento="A1",
+        certificado_origen=0,
+        tipo_cambio_usd=Decimal("18.78"),
+        total_usd=Decimal("100"),
+        mercancias=cce20.Mercancia(
+            no_identificacion="CX-000988",
+            valor_dolares=Decimal("100"),
+            fraccion_arancelaria="94059102",
+            cantidad_aduana=Decimal("1"),
+            unidad_aduana="01",
+            valor_unitario_aduana=Decimal("100"),
+        ),
+        emisor=cce20.Emisor(
+            domicilio=cce20.Domicilio(
+                calle="Canada de Gomez",
+                estado="SLP",
+                pais="MEX",
+                codigo_postal="78216",
+                numero_exterior="110",
+                municipio="028",
+            )
+        ),
+        receptor=cce20.Receptor(
+            num_reg_id_trib="123456789",
+            domicilio=cce20.Domicilio(
+                calle="Main St",
+                estado="TX",
+                pais="USA",
+                codigo_postal="75001",
+                numero_exterior="1",
+            ),
+        ),
+        incoterm="CFR",
+    )
+    invoice = cfdi40.Comprobante(
+        emisor=cfdi40.Emisor(
+            rfc=signer.rfc,
+            nombre=signer.legal_name,
+            regimen_fiscal="601",
+        ),
+        lugar_expedicion="78116",
+        fecha=datetime.fromisoformat("2022-09-28T22:40:38"),
+        receptor=cfdi40.Receptor(
+            rfc="XEXX010101000",
+            nombre="JOSE ALBERTO LOPEZ",
+            uso_cfdi="S01",
+            domicilio_fiscal_receptor="78116",
+            regimen_fiscal_receptor="616",
+            residencia_fiscal="USA",
+            num_reg_id_trib="123456789",
+        ),
+        forma_pago="01",
+        metodo_pago="PUE",
+        exportacion="02",
+        conceptos=cfdi40.Concepto(
+            clave_prod_serv="41106300",
+            no_identificacion="CX-000988",
+            cantidad=Decimal("1"),
+            clave_unidad="EA",
+            descripcion="ABACO",
+            valor_unitario=Decimal("100"),
+            objeto_imp="02",
+            impuestos=cfdi40.Impuestos(
+                traslados=cfdi40.Traslado(
+                    impuesto=Impuesto.IVA,
+                    tipo_factor=TipoFactor.TASA,
+                    tasa_o_cuota=Decimal("0.160000"),
+                ),
+            ),
+        ),
+        complemento=cce,
+    )
+    try:
+        cfdi_to_facturama_payload(invoice)
+        assert False, "expected NotImplementedError"
+    except NotImplementedError as exc:
+        assert "FacturamaWeb" in str(exc)
+
+    payload = cfdi_to_facturama_payload(invoice, allow_foreign_trade=True)
+    verify = verify_result(
+        data=json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True),
+        filename="test_payload_foreign_trade.json",
+    )
+    assert verify
+    assert payload["NameId"] == "26"
+    assert payload["Receiver"]["TaxRegistrationNumber"] == "123456789"
+    assert payload["Receiver"]["TaxResidence"] == "USA"
+    ft = payload["Complemento"]["ForeignTrade"]
+    assert ft["RequestCode"] == "A1"
+    assert ft["OriginCertificate"] is False
+    assert ft["Commodity"][0]["IdentificationNumber"] == "CX-000988"
+    assert ft["Issuer"]["Address"]["ZipCode"] == "78216"
+
+
+def test_facturama_web_issue_uses_api3():
+    pac = FacturamaWeb("user", "password", Environment.TEST)
+    invoice = _sample_invoice()
+    with mock.patch("requests.request") as mk:
+        create_response = mock.Mock()
+        create_response.ok = True
+        create_response.content = b'{"Id":"web123"}'
+        create_response.headers = {"Content-Type": "application/json"}
+        create_response.json = mock.Mock(return_value={"Id": "web123"})
+
+        xml_response = mock.Mock()
+        xml_response.ok = True
+        xml_response.content = b'{"Content":"PD94bWwgdmVyc2lvbj0iMS4wIj8+PGNmZGk+dGVzdDwvY2ZkaT4="}'
+        xml_response.headers = {"Content-Type": "application/json"}
+        xml_response.json = mock.Mock(
+            return_value={"Content": "PD94bWwgdmVyc2lvbj0iMS4wIj8+PGNmZGk+dGVzdDwvY2ZkaT4="}
+        )
+        mk.side_effect = [create_response, xml_response]
+
+        res = pac.issue(cfdi=invoice, accept=Accept.XML)
+        assert res.document_id == "web123"
+        assert mk.call_args_list[0].kwargs["url"].endswith("api/3/cfdis")
+        assert "issued/" in mk.call_args_list[1].kwargs["url"]
+        assert "issuedLite" not in mk.call_args_list[1].kwargs["url"]
+
+
+def test_facturama_web_csd_not_supported():
+    pac = FacturamaWeb("user", "password", Environment.TEST)
+    try:
+        pac.upload_csd("XIQB891116QE4", b"CER", b"KEY", "secret")
+        assert False, "expected NotImplementedError"
+    except NotImplementedError as exc:
+        assert "FacturamaWeb" in str(exc) or "fiscal profile" in str(exc)
+
+
+def test_facturama_send_email():
+    pac = Facturama("user", "password", Environment.TEST)
+    with mock.patch("requests.request") as mk:
+        mk.return_value.ok = True
+        mk.return_value.content = b'{"success":true}'
+        mk.return_value.headers = {"Content-Type": "application/json"}
+        mk.return_value.json = mock.Mock(return_value={"success": True})
+        pac.send_email("abc123", "test@example.com")
+        assert mk.call_args.kwargs["params"]["cfdiId"] == "abc123"
+        assert mk.call_args.kwargs["params"]["email"] == "test@example.com"
+        assert mk.call_args.kwargs["params"]["cfdiType"] == "issuedLite"
 
 
 def test_facturama_cancel_by_uuid():

--- a/tests/test_pac_facturama/test_issue.json
+++ b/tests/test_pac_facturama/test_issue.json
@@ -28,6 +28,7 @@
           "Taxes": [
             {
               "Base": 100.0,
+              "IsFederalTax": true,
               "IsQuota": false,
               "IsRetention": false,
               "Name": "IVA",
@@ -36,6 +37,7 @@
             },
             {
               "Base": 100.0,
+              "IsFederalTax": true,
               "IsQuota": false,
               "IsRetention": true,
               "Name": "ISR",

--- a/tests/test_pac_facturama/test_payload.json
+++ b/tests/test_pac_facturama/test_payload.json
@@ -20,6 +20,7 @@
       "Taxes": [
         {
           "Base": 100.0,
+          "IsFederalTax": true,
           "IsQuota": false,
           "IsRetention": false,
           "Name": "IVA",
@@ -28,6 +29,7 @@
         },
         {
           "Base": 100.0,
+          "IsFederalTax": true,
           "IsQuota": false,
           "IsRetention": true,
           "Name": "ISR",

--- a/tests/test_pac_facturama/test_payload_carta_porte.json
+++ b/tests/test_pac_facturama/test_payload_carta_porte.json
@@ -1,0 +1,127 @@
+{
+  "CfdiType": "T",
+  "Complemento": {
+    "CartaPorte31": {
+      "FiguraTransporte": [
+        {
+          "Domicilio": {
+            "Calle": "Calle1",
+            "CodigoPostal": "78000",
+            "Estado": "SLP",
+            "NumeroExterior": "100",
+            "Pais": "MEX"
+          },
+          "NombreFigura": "Operador Uno",
+          "NumLicencia": "NumLicencia1",
+          "RFCFigura": "EKU9003173C9",
+          "TipoFigura": "01"
+        }
+      ],
+      "IdCCP": "CCCBB0A0-A0A0-0A00-000A-0A0A000A000A",
+      "Mercancias": {
+        "Autotransporte": {
+          "IdentificacionVehicular": {
+            "AnioModeloVM": 2020,
+            "ConfigVehicular": "VL",
+            "PesoBrutoVehicular": 1.0,
+            "PlacaVM": "ABC1234"
+          },
+          "NumPermisoSCT": "NumPermisoSCT1",
+          "PermSCT": "TPAF01",
+          "Remolques": [
+            {
+              "Placa": "VL45K98",
+              "SubTipoRem": "CTR004"
+            }
+          ],
+          "Seguros": {
+            "AseguraRespCivil": "AseguraRespCivil",
+            "PolizaRespCivil": "123456789"
+          }
+        },
+        "Mercancia": [
+          {
+            "BienesTransp": "11121900",
+            "Cantidad": 1.0,
+            "CantidadTransporta": [
+              {
+                "Cantidad": 1.0,
+                "IDDestino": "DE000001",
+                "IDOrigen": "OR000001"
+              }
+            ],
+            "ClaveUnidad": "XBX",
+            "Descripcion": "Accesorios de equipo de telefonía",
+            "MaterialPeligroso": "No",
+            "PesoEnKg": 1.0
+          }
+        ],
+        "NumTotalMercancias": 1,
+        "PesoBrutoTotal": 1.0,
+        "UnidadPeso": "KGM"
+      },
+      "TotalDistRec": 120.5,
+      "TranspInternac": "No",
+      "Ubicaciones": [
+        {
+          "Domicilio": {
+            "CodigoPostal": "78000",
+            "Estado": "SLP",
+            "Localidad": "05",
+            "Municipio": "028",
+            "Pais": "MEX"
+          },
+          "FechaHoraSalidaLlegada": "2022-05-16 15:15:00",
+          "IDUbicacion": "OR000001",
+          "RFCRemitenteDestinatario": "XIQB891116QE4",
+          "TipoUbicacion": "Origen"
+        },
+        {
+          "DistanciaRecorrida": 120.5,
+          "Domicilio": {
+            "CodigoPostal": "78000",
+            "Estado": "SLP",
+            "Localidad": "05",
+            "Municipio": "028",
+            "Pais": "MEX"
+          },
+          "FechaHoraSalidaLlegada": "2022-05-16 18:15:00",
+          "IDUbicacion": "DE000001",
+          "RFCRemitenteDestinatario": "URE180429TM6",
+          "TipoUbicacion": "Destino"
+        }
+      ]
+    }
+  },
+  "Currency": "MXN",
+  "Date": "2022-05-16 15:00:00",
+  "ExpeditionPlace": "78000",
+  "Exportation": "01",
+  "Folio": "1",
+  "Issuer": {
+    "FiscalRegime": "601",
+    "Name": "BERENICE XIMO QUEZADA",
+    "Rfc": "XIQB891116QE4"
+  },
+  "Items": [
+    {
+      "Description": "MERCANCIA EN TRASLADO",
+      "ProductCode": "24111506",
+      "Quantity": 1.0,
+      "Subtotal": 0.0,
+      "TaxObject": "01",
+      "Total": 0.0,
+      "UnitCode": "H87",
+      "UnitPrice": 0.0
+    }
+  ],
+  "NameId": "36",
+  "Receiver": {
+    "CfdiUse": "S01",
+    "FiscalRegime": "601",
+    "Name": "UNIVERSIDAD ROBOTICA ESPAÑOLA",
+    "Rfc": "URE180429TM6",
+    "TaxZipCode": "65000"
+  },
+  "Serie": "CP"
+}

--- a/tests/test_pac_facturama/test_payload_donation.json
+++ b/tests/test_pac_facturama/test_payload_donation.json
@@ -1,0 +1,43 @@
+{
+  "CfdiType": "I",
+  "Complemento": {
+    "Donation": {
+      "AuthorizationDate": "30/01/2019",
+      "AuthorizationNumber": "B400-05-08-2014-005",
+      "Legend": "El comprobante es un donativo"
+    }
+  },
+  "Currency": "MXN",
+  "Date": "2019-06-19 13:45:00",
+  "ExpeditionPlace": "51873",
+  "Exportation": "01",
+  "Folio": "94",
+  "Issuer": {
+    "FiscalRegime": "601",
+    "Name": "BERENICE XIMO QUEZADA",
+    "Rfc": "XIQB891116QE4"
+  },
+  "Items": [
+    {
+      "Description": "Cobija de lana y algodon",
+      "ProductCode": "20102000",
+      "Quantity": 3.0,
+      "Subtotal": 3000.0,
+      "TaxObject": "01",
+      "Total": 3000.0,
+      "UnitCode": "EA",
+      "UnitPrice": 1000.0
+    }
+  ],
+  "NameId": "9",
+  "PaymentForm": "12",
+  "PaymentMethod": "PUE",
+  "Receiver": {
+    "CfdiUse": "D04",
+    "FiscalRegime": "605",
+    "Name": "CECILIA MIRANDA SANCHEZ",
+    "Rfc": "MISC491214B86",
+    "TaxZipCode": "65010"
+  },
+  "Serie": "D"
+}

--- a/tests/test_pac_facturama/test_payload_foreign_trade.json
+++ b/tests/test_pac_facturama/test_payload_foreign_trade.json
@@ -1,0 +1,87 @@
+{
+  "CfdiType": "I",
+  "Complemento": {
+    "ForeignTrade": {
+      "Commodity": [
+        {
+          "CustomsQuantity": "1.0",
+          "CustomsUnit": "01",
+          "CustomsUnitValue": 100.0,
+          "IdentificationNumber": "CX-000988",
+          "TariffFraction": "94059102",
+          "ValueInDolar": 100.0
+        }
+      ],
+      "ExchangeRateUSD": 18.78,
+      "Incoterm": "CFR",
+      "Issuer": {
+        "Address": {
+          "Country": "MEX",
+          "ExteriorNumber": "110",
+          "Municipality": "028",
+          "State": "SLP",
+          "Street": "Canada de Gomez",
+          "ZipCode": "78216"
+        }
+      },
+      "OriginCertificate": false,
+      "Receiver": {
+        "Address": {
+          "Country": "USA",
+          "ExteriorNumber": "1",
+          "State": "TX",
+          "Street": "Main St",
+          "ZipCode": "75001"
+        },
+        "NumRegIdTrib": "123456789"
+      },
+      "RequestCode": "A1",
+      "TotalUSD": 100.0
+    }
+  },
+  "Currency": "MXN",
+  "Date": "2022-09-28 22:40:38",
+  "ExpeditionPlace": "78116",
+  "Exportation": "02",
+  "Issuer": {
+    "FiscalRegime": "601",
+    "Name": "BERENICE XIMO QUEZADA",
+    "Rfc": "XIQB891116QE4"
+  },
+  "Items": [
+    {
+      "Description": "ABACO",
+      "IdentificationNumber": "CX-000988",
+      "ProductCode": "41106300",
+      "Quantity": 1.0,
+      "Subtotal": 100.0,
+      "TaxObject": "02",
+      "Taxes": [
+        {
+          "Base": 100.0,
+          "IsFederalTax": true,
+          "IsQuota": false,
+          "IsRetention": false,
+          "Name": "IVA",
+          "Rate": 0.16,
+          "Total": 16.0
+        }
+      ],
+      "Total": 116.0,
+      "UnitCode": "EA",
+      "UnitPrice": 100.0
+    }
+  ],
+  "NameId": "26",
+  "PaymentForm": "01",
+  "PaymentMethod": "PUE",
+  "Receiver": {
+    "CfdiUse": "S01",
+    "FiscalRegime": "616",
+    "Name": "JOSE ALBERTO LOPEZ",
+    "Rfc": "XEXX010101000",
+    "TaxRegistrationNumber": "123456789",
+    "TaxResidence": "USA",
+    "TaxZipCode": "78116"
+  }
+}


### PR DESCRIPTION
## Summary
- Multiemisor mapper: **Carta Porte 3.1** (`NameId` 36), **Donativos** (`NameId` 9), **Leyendas fiscales**, and **Impuestos locales** (item `Taxes` with `IsFederalTax: false`; federal taxes set `IsFederalTax: true`).
- Adds **`FacturamaWeb`** for API Web (`api/3/cfdis`, `issued`) plus **`send_email`** on both adapters.
- Maps **Comercio Exterior 2.0** (`NameId` 26 / `ForeignTrade`) for API Web only; Multiemisor raises a clear error pointing to `FacturamaWeb`.

## Test plan
- [x] `pytest tests/test_pac_facturama.py`
- [ ] Optional: Multiemisor sandbox (Carta Porte / Donativos / Leyendas / Impuestos locales)
- [ ] Optional: API Web sandbox (Comercio Exterior + `send_email`)